### PR TITLE
ci: run build & unit tests in GH Actions

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -eux
+set -o pipefail
+
+# TODO
+#   - enable --werror
+#       - currently there's a lot of warnings which need to be taken care of first
+#   - re-enable test-polkitbackendjsauthority
+#       - mocklibc overrides LD_PRELOAD, causing ASan to report false positives
+#         (with asan_verify_no_link=0)
+#   - re-enable unit tests built with ASan + sanitizers
+#       - currently polkit fails to build with clang >= 17 completely, and
+#         with older clang it needs to be built with -shared-libasan, which
+#         requires another set of tweaks to the environment
+
+PHASE="${1:?}"
+COMMON_BUILD_OPTS=(
+    -Dauthfw=pam
+    -Dexamples=true
+    -Dgtk_doc=true
+    -Dintrospection=true
+    -Dsession_tracking=libsystemd-login
+    -Dtests=true
+)
+
+if [[ "$PHASE" =~ ^CLANG_ ]]; then
+    export CC=clang
+    export CXX=clang++
+fi
+
+case "$PHASE" in
+    BUILD_GCC|BUILD_CLANG)
+        # Build test with various levels of optimization and other flags affecting the build
+
+        BUILD_TEST_FLAGS=(
+            --optimization=0
+            --optimization=3
+            --optimization=s
+            -Db_ndebug=true
+        )
+
+        for opt in "${BUILD_TEST_FLAGS[@]}"; do
+            meson setup build \
+                -Dman=true \
+                -Dcpp_args="-D_FORTIFY_SOURCE=2" \
+                "${COMMON_BUILD_OPTS[@]}" \
+                "$opt"
+            meson compile -C build -v
+            rm -rf build
+         done
+         ;;
+
+    GCC|CLANG)
+        # Build + unit tests
+
+        meson setup build \
+            -Dman=true \
+            -Dcpp_args="-D_FORTIFY_SOURCE=2" \
+            "${COMMON_BUILD_OPTS[@]}"
+
+        meson compile -C build -v
+        meson test -C build --print-errorlogs
+        DESTDIR="$PWD/install-test" meson install -C build
+        ;;
+
+    GCC_ASAN_UBSAN|CLANG_ASAN_UBSAN)
+        # Build + unit tests with ASan and UBSan
+
+        meson setup build \
+            -Dman=false \
+            -Db_sanitize=address,undefined \
+            --optimization=1 \
+            -Db_lundef=false \
+            "${COMMON_BUILD_OPTS[@]}"
+
+        # Note: we need to set verify_asan_link_order=0 as polkit LD_PRELOADs libmocklibc in unit tests
+        export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:verify_asan_link_order=0
+        export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
+
+        meson compile -C build -v
+        meson test -C build --print-errorlogs
+        ;;
+    *)
+        echo >&2 "Unknown phase '$PHASE'"
+        exit 1
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+---
+# vi: ts=2 sw=2 et:
+
+name: Build & test
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.phase }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        phase: [BUILD_GCC, GCC, GCC_ASAN_UBSAN, BUILD_CLANG, CLANG]
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+
+      - name: Install build & test dependencies
+        run: |
+          sudo dnf install -y dnf-plugins-core python3-dbusmock clang compiler-rt libasan libubsan
+          sudo dnf builddep -y polkit
+
+      - name: Build & test
+        run: sudo --preserve-env=GITHUB_ACTIONS,CI .github/workflows/ci.sh ${{ matrix.phase }}

--- a/test/polkit/polkitidentitytest.c
+++ b/test/polkit/polkitidentitytest.c
@@ -167,6 +167,7 @@ add_comparison_tests (void)
     struct ComparisonTestData *test_data = &comparison_test_data[i];
     gchar *test_name = g_strdup_printf ("/PolkitIdentity/comparison_%d", i);
     g_test_add_data_func (test_name, test_data, test_comparison);
+    g_free(test_name);
   }
 }
 

--- a/test/polkitbackend/meson.build
+++ b/test/polkitbackend/meson.build
@@ -24,10 +24,14 @@ exe = executable(
 
 prog = find_program('polkitbackendjsauthoritytest-wrapper.py')
 
-test(
-  test_unit,
-  prog,
-  env: test_env,
-  is_parallel: false,
-  timeout: 90,
-)
+if not get_option('b_sanitize').split(',').contains('address')
+  test(
+    test_unit,
+    prog,
+    env: test_env,
+    is_parallel: false,
+    timeout: 90,
+  )
+else
+  warning('@0@ is not (yet) compatible with AddressSanitizer, skipping'.format(test_unit))
+endif

--- a/test/polkitbackend/polkitbackendjsauthoritytest-wrapper.py
+++ b/test/polkitbackend/polkitbackendjsauthoritytest-wrapper.py
@@ -69,11 +69,10 @@ class TestPolkitBackendJsAuthority(dbusmock.DBusTestCase):
             print('\n %s... not found' % test_path)
             test_path = self.top_build_dir + '/test/polkitbackend/polkitbackendjsauthoritytest'
 
-        out = subprocess.check_output(self.mocklibc_path + ' ' + test_path,
-                                      stderr=subprocess.STDOUT,
-                                      shell=True,
-                                      universal_newlines=True)
-        print(out)
+        subprocess.run(self.mocklibc_path + ' ' + test_path,
+                       check=True,
+                       shell=True,
+                       universal_newlines=True)
 
 if __name__ == '__main__':
     # avoid writing to stderr


### PR DESCRIPTION
Introduce a GH Actions job that builds & tests polkit in three
"categories":

1) Build with various optimization levels & other build-time options
   (both clang & gcc)

2) Build & run the unit tests (both clang & gcc)

3) Build & run the unit tests with Address Sanitizer and
   Undefined Behavior Sanitizer (only gcc for now)

There's a couple of outstanding issues that should be taken care of in
the near future:

 - get rid of the gazillion of warnings during compilation so we can
   build with -Werror (--werror)
 - fix build with clang >= 17
 - make test-polkitbackendjsauthority work under ASan