### PR TITLE
meson: decouple session tracking mechanism from unit and sysusers

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -30,25 +30,28 @@ if enable_pam
   )
 endif
 
-if session_tracking == 'logind'
-  configure_file(
-    input: 'polkit.service.in',
-    output: '@BASENAME@',
-    configuration: service_conf,
-    install: true,
-    install_dir: systemd_systemdsystemunitdir,
-  )
+configure_file(
+  input: 'polkit.service.in',
+  output: '@BASENAME@',
+  configuration: service_conf,
+  install: true,
+  install_dir: systemdsystemunitdir,
+)
 
-  configure_file(
-    input: 'polkit.conf.in',
-    output: '@BASENAME@',
-    configuration: service_conf,
-    install: true,
-    install_dir: systemd_sysusers_dir,
-  )
-endif
+configure_file(
+  input: 'polkit.conf.in',
+  output: '@BASENAME@',
+  configuration: service_conf,
+  install: true,
+  install_dir: sysusers_dir,
+)
 
 install_data(
   'policyconfig-1.dtd',
   install_dir: pk_datadir / 'polkit-1'
+)
+
+install_data(
+  'polkit-tmpfiles.conf',
+  install_dir: tmpfiles_dir
 )

--- a/meson.build
+++ b/meson.build
@@ -191,16 +191,6 @@ enable_logind = (session_tracking != 'ConsoleKit')
 if enable_logind
   if session_tracking == 'logind'
     logind_dep = dependency('libsystemd', not_found_message: 'logind support requested but libsystemd library not found')
-
-    # systemd unit / service files
-    systemd_systemdsystemunitdir = get_option('systemdsystemunitdir')
-    if systemd_systemdsystemunitdir == ''
-      systemd_dep = dependency('systemd', not_found_message: 'systemd required but not found, please provide a valid systemd user unit dir or disable it')
-      # FIXME: systemd.pc file does not use variables with relative paths, so `define_variable` cannot be used
-      systemd_systemdsystemunitdir = systemd_dep.get_variable(pkgconfig: 'systemdsystemunitdir')
-    endif
-
-    systemd_sysusers_dir = systemd_dep.get_variable(pkgconfig: 'sysusers_dir', default_value: '/usr/lib/sysusers.d')
   else
     logind_dep = dependency('libelogind', not_found_message: 'elogind support requested but libelogind library not found')
   endif
@@ -212,19 +202,25 @@ if enable_logind
 endif
 config_data.set('HAVE_LIBSYSTEMD', enable_logind)
 
-systemd_dep = dependency('systemd').found()
-if systemd_dep
-  tmpfiles_conf = files(
-    'data/polkit-tmpfiles.conf'
-  )
-
-  install_data(
-    tmpfiles_conf,
-    install_dir: pk_prefix / 'lib/tmpfiles.d/'
-  )
-endif
-
 config_data.set('HAVE_PIDFD_OPEN', cc.get_define('SYS_pidfd_open', prefix: '#include <sys/syscall.h>') != '')
+
+# systemd unit / sysuser / tmpfiles.d file installation directories
+systemdsystemunitdir = get_option('systemdsystemunitdir')
+systemd_dep = dependency('systemd', required : false)
+if systemd_dep.found()
+  if systemdsystemunitdir == ''
+    # FIXME: systemd.pc file does not use variables with relative paths, so `define_variable` cannot be used
+    systemdsystemunitdir = systemd_dep.get_variable(pkgconfig : 'systemdsystemunitdir')
+  endif
+  sysusers_dir = systemd_dep.get_variable(pkgconfig : 'sysusers_dir')
+  tmpfiles_dir = systemd_dep.get_variable(pkgconfig : 'tmpfiles_dir')
+else
+  if systemdsystemunitdir == ''
+    systemdsystemunitdir = '/usr/lib/systemd/system'
+  endif
+  sysusers_dir = '/usr/lib/sysusers.d'
+  tmpfiles_dir = '/usr/lib/tmpfiles.d'
+endif
 
 # User for running polkitd
 polkitd_user = get_option('polkitd_user')
@@ -409,12 +405,9 @@ output += '        introspection:            ' + enable_introspection.to_string(
 output += '        Distribution/OS:          ' + os_type + '\n'
 output += '        Authentication framework: ' + auth_fw + '\n'
 output += '        Session tracking:         ' + session_tracking + '\n'
-if session_tracking == 'logind'
-  output += '        systemdsystemunitdir:     ' + systemd_systemdsystemunitdir + '\n'
-endif
-if systemd_dep
-  output += '        systemdtmpfilesdir:       ' + pk_prefix + '/lib/tmpfiles.d' + '\n'
-endif
+output += '        system unit directory:    ' + systemdsystemunitdir + '\n'
+output += '        sysusers.d directory:     ' + sysusers_dir + '\n'
+output += '        tmpfiles.d directory:     ' + tmpfiles_dir + '\n'
 
 output += '        polkitd user:             ' + polkitd_user + ' \n'
 if polkitd_uid != '-'


### PR DESCRIPTION
Session tracking build options are about whether logind or other APIs
are used in the polkit code, at compilation and linking time.

units, sysusers and tmpfiles files have nothing to do with code changes
or APIs, they simply install config files, that can just be ignored if
they are not needed. Use pkg-config if available, but otherwise have
a hard-coded fallback with the well-known defaults.

This also fixes another bug,  'systemdsystemunitdir' is specified as
an option the systemd_dep variable is not defined, but the sysusers.d
directory lookup uses it, causing a build failure:

```
dh_auto_configure -- \
	-Dexamples=false \
	-Dintrospection=true \
	-Dman=true \
	-Dsystemdsystemunitdir=/usr/lib/systemd/system \
	-Dtests=true \
	-Dgtk_doc=true -Dsession_tracking=libsystemd-login
	cd obj-x86_64-linux-gnu && DEB_PYTHON_INSTALL_LAYOUT=deb LC_ALL=C.UTF-8 meson setup .. --wrap-mode=nodownload --buildtype=plain --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu -Dpython.bytecompile=-1 -Dexamples=false -Dintrospection=true -Dman=true -Dsystemdsystemunitdir=/usr/lib/systemd/system -Dtests=true -Dgtk_doc=true -Dsession_tracking=libsystemd-login
The Meson build system
Version: 1.3.1
Source dir: /builds/bluca/polkit/debian/output/source_dir Build dir: /builds/bluca/polkit/debian/output/source_dir/obj-x86_64-linux-gnu Build type: native build
Project name: polkit
Project version: 124

<...>

Run-time dependency libsystemd found: YES 255
Checking for function "sd_uid_get_display" with dependency libsystemd: YES
Checking for function "sd_pidfd_get_session" with dependency libsystemd: YES
../meson.build:222:37: ERROR: Unknown variable "systemd_dep".
```

Follow-up for 24f1e0af3f7bd17e220cb96201f3c654e737ad34