### PR TITLE
ci: introduce CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+---
+# vi: ts=2 sw=2 et:
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.ref }}-${{ matrix.language }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['c-cpp', 'javascript-typescript', 'python']
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        queries: +security-extended,security-and-quality
+
+    - name: Install dependencies
+      if: ${{ matrix.language == 'c-cpp' }}
+      run: |
+        sudo add-apt-repository -y --no-update --enable-source
+        sudo apt update
+        sudo apt build-dep -y policykit-1
+        # polkit in Ubuntu Jammy (ATTOW) doesn't have the latest build dependencies yet
+        sudo apt install -y duktape-dev meson
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Analyze the polkit code using CodeQL [0], to discover potential vulnerabilities before they reach the main branch.

[0] https://codeql.github.com/docs/

---

Once this is merged, it'll do the initial scan and populate the "Code Scanning" tab in the "Security" repo section, like this:

![Screenshot_20240131_204338](https://github.com/polkit-org/polkit/assets/679338/5ef6cd97-f70e-424f-81db-710c1504de21)

(This tab is accessible only to the repo maintainers, given the sensitive nature of some of the alerts.)

Each alert then shows further information and steps how to remediate it:

![Screenshot_20240131_204601](https://github.com/polkit-org/polkit/assets/679338/340d2bbb-e620-4725-bb27-d3ee5024343f)

I enabled the extended CodeQL queries as well (as I think polkit would benefit from them, given its security nature). However, the extended checks are more prone to false positives, so if that's something you'll find annoying, it can be easily toned back down to only high-precision checks.

The results of the initial scan will be in the Security tab, but any issues introduced in new code will be shown directly in the respective PR that introduced them, so they can be acted on immediately.
