### PR TITLE
pkexec: enforce absolute shell paths

### DIFF
--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -372,7 +372,7 @@ is_valid_shell (const gchar *shell)
   shells = g_strsplit (contents, "\n", 0);
   for (n = 0; shells != NULL && shells[n] != NULL; n++)
     {
-      if (g_strcmp0 (shell, shells[n]) == 0)
+      if (shells[n][0] == '/' && g_strcmp0 (shell, shells[n]) == 0)
         {
           ret = TRUE;
           goto out;


### PR DESCRIPTION
Reading `/etc/shells` file directly has the effect that comments are parsed as well. If a user sets environment variable `SHELL` to a value which matches one of these comments, it is passed through pkexec.

The shadow tools would not allow such a login shell, so be as strict as shadow when it comes to parsing `/etc/shell`.

Proof of Concept:
1. Add a comment to `/etc/shells` (if it does not already exist)
```
# Begin /etc/shells

/bin/sh
/bin/bash

# End /etc/shells
```
2. For sake of completeness, try to add a comment line through latest `chsh` of shadow:
```
$ chsh -s '# Begin /etc/shells'
chsh: # Begin /etc/shells is an invalid shell
```
3. Run `pkexec` with `SHELL` being one of the comment lines
```
$ SHELL="# Begin /etc/shells" pkexec
```

You can see:
```
==== AUTHENTICATING FOR org.freedesktop.policykit.exec ====
Authentication is needed to run `/bin/bash' as the super user
Authenticating as: root
Password:
```

What should be seen:
```
The value for the SHELL variable was not found in the /etc/shells file

This incident has been reported.
```