### PR TITLE
fix: pkexec fails with "GDBus.Error:org.freedesktop.PolicyKit1.Error.…

### DIFF
--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -2611,7 +2611,8 @@ polkit_backend_interactive_authority_register_authentication_agent (PolkitBacken
   priv->agent_serial++;
   agent = authentication_agent_new (priv->agent_serial,
                                     subject,
-                                    user_of_caller,
+                                    user_of_subject,/*fix pkexec fails with No session for cookie,
+                                    upstream issue:https://gitlab.freedesktop.org/polkit/polkit/issues/17*/
                                     polkit_system_bus_name_get_name (POLKIT_SYSTEM_BUS_NAME (caller)),
                                     locale,
                                     object_path,


### PR DESCRIPTION
…Failed: No session for cookie"

bug:https://gitlab.freedesktop.org/polkit/polkit/-/issues/17

Jrybar: It makes sense that an agent is created against the UID of subject, because we want to authenticate THAT user. Using EUID 'root' doesn't seem necessary here and also causes the issue.

Resolves #269 
Resolves #238 
Resolves #18 