### PR TITLE
doc: document --no-debug, which is set by default in our own systemd …

### DIFF
--- a/docs/man/polkit.xml
+++ b/docs/man/polkit.xml
@@ -666,8 +666,18 @@ polkit.Result = {
         with the JavaScript filename and line number. Log entries are
         emitted using the <constant>LOG_AUTHPRIV</constant> flag meaning
         that the log entries usually ends up in the file
-        <filename>/var/log/secure</filename>. The
-        <function>log()</function> method is usually only used when
+        <filename>/var/log/secure</filename> or in
+        <command>journalctl -b SYSLOG_FACILITY=10</command> on systemd.
+      </para>
+      <para>
+        On some distributions, the flag <literal>--no-debug</literal> is passed
+        to <command>polkitd</command> by default, discarding log output. This
+        means that to debug a rule, it must removed first, say with
+        <command>systemctl edit --runtime polkit.service</command>, for the
+        current boot.
+      </para>
+      <para>
+        The <function>log()</function> method is usually only used when
         debugging rules. The <type>Action</type> and
         <type>Subject</type> types has suitable
         <function>toString()</function> methods defined for easy

--- a/docs/man/polkitd.xml
+++ b/docs/man/polkitd.xml
@@ -24,6 +24,9 @@
   <refsynopsisdiv>
     <cmdsynopsis>
       <command>polkitd</command>
+      <arg><option>--replace|-r</option></arg>
+      <arg><option>--no-debug|-n</option></arg>
+      <arg><option>--help|-h</option></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -38,6 +41,12 @@
       or
       <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>
       whenever an application calls into the service.
+    </para>
+
+    <para>
+      Passing the <option>--no-debug</option> to <command>polkitd</command>
+      will discard the messages from usages of <literal>polkit.log()</literal>
+      in rules.
     </para>
 
     <para>


### PR DESCRIPTION
…service

This can be immensely frustrating to users since there is no mention whatsoever in the documentation of why their logs are getting eaten.

Fixes #154.