### PR TITLE
mocklibc: move the print_indent function to the file where it is used

### DIFF
--- a/test/mocklibc/src/netgroup-debug.c
+++ b/test/mocklibc/src/netgroup-debug.c
@@ -21,6 +21,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/**
+ * Print a varaible indentation to the stream.
+ * @param stream Stream to print to
+ * @param indent Number of indents to use
+ */
+static void print_indent(FILE *stream, unsigned int indent) {
+  int i;
+  for (i = 0; i < indent; i++)
+    fprintf(stream, "  ");
+}
+
 void netgroup_debug_print_entry(struct entry *entry, FILE *stream, unsigned int indent) {
   print_indent(stream, indent);
 

--- a/test/mocklibc/src/netgroup.c
+++ b/test/mocklibc/src/netgroup.c
@@ -72,17 +72,6 @@ static char *parser_copy_word(char **cur) {
 }
 
 /**
- * Print a varaible indentation to the stream.
- * @param stream Stream to print to
- * @param indent Number of indents to use
- */
-void print_indent(FILE *stream, unsigned int indent) {
-  int i;
-  for (i = 0; i < indent; i++)
-    fprintf(stream, "  ");
-}
-
-/**
  * Connect entries with 'child' type to their child entries.
  * @param headentry Head of list of entries that need to be connected
  * @param headgroup Head of list of netgroups to connect child entries to


### PR DESCRIPTION
This fixes build error with GCC >= 14 and clang >= 17, failing on:
```
../subprojects/mocklibc-1.0/src/netgroup-debug.c:25:3: error: implicit declaration of function ‘print_indent’ [-Wimplicit-function-declaration]
   25 |   print_indent(stream, indent);
      |   ^~~~~~~~~~~~
```

Issue reported 11 years ago to (dead) upstream: https://code.google.com/archive/p/mocklibc/issues/3.

Closes: #6 