### PR TITLE
meson.build: allow overriding sysusers.d dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -219,7 +219,10 @@ if enable_logind
     systemd_systemdsystemunitdir = systemd_dep.get_pkgconfig_variable('systemdsystemunitdir')
   endif
 
-  systemd_sysusers_dir = systemd_dep.get_pkgconfig_variable('sysusers_dir', default: '/usr/lib/sysusers.d')
+  systemd_sysusers_dir = get_option('systemdsysusersdir')
+  if systemd_sysusers_dir == '' and session_tracking == 'libsystemd-login'
+    systemd_sysusers_dir = systemd_dep.get_pkgconfig_variable('sysusers_dir', default: '/usr/lib/sysusers.d')
+  endif
 endif
 config_h.set('HAVE_LIBSYSTEMD', enable_logind)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('session_tracking', type: 'combo', choices: ['libsystemd-login', 'libelogind', 'ConsoleKit'], value: 'ConsoleKit', description: 'session tracking (libsystemd-login/libelogind/ConsoleKit)')
 option('systemdsystemunitdir', type: 'string', value: '', description: 'custom directory for systemd system units')
+option('systemdsysusersdir', type: 'string', value: '', description: 'custom directory for systemd sysusers')
 
 option('libs-only', type: 'boolean', value: false, description: 'Only build libraries (skips building polkitd)')
 option('polkitd_user', type: 'string', value: 'polkitd', description: 'User for running polkitd (polkitd)')


### PR DESCRIPTION
fixes builds for non-FHS systems like Nix.