### PR TITLE
Add similar feature of Linux's prctl() for FreeBSD, using procctl(2)

### DIFF
--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -37,6 +37,11 @@
 #include <sys/prctl.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <signal.h>
+#include <sys/procctl.h>
+#endif
+
 #include <glib/gi18n.h>
 
 #ifdef POLKIT_AUTHFW_PAM
@@ -731,10 +736,17 @@ main (int argc, char *argv[])
     }
 
   /* make sure we are nuked if the parent process dies */
-#ifdef __linux__
+#if defined(__linux__)
   if (prctl (PR_SET_PDEATHSIG, SIGTERM) != 0)
     {
       g_printerr ("prctl(PR_SET_PDEATHSIG, SIGTERM) failed: %s\n", g_strerror (errno));
+      goto out;
+    }
+#elif defined(__FreeBSD__)
+  int _sig = SIGTERM;
+  if (procctl (P_PID, 0, PROC_PDEATHSIG_CTL, &_sig) != 0)
+    {
+      g_printerr ("procctl(2) failed: %s\n", g_strerror (errno));
       goto out;
     }
 #else


### PR DESCRIPTION
This is a resubmitted patch by Olivier Duchateau from the previous GitLab hosting. Closes https://github.com/polkit-org/polkit/issues/356