### PR TITLE
tmpfiles.d: install and use systemd-tmpfiles.d mechanism to .packit conf

### DIFF
--- a/.packit/polkit.spec
+++ b/.packit/polkit.spec
@@ -137,6 +137,7 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_bindir}/pkttyagent
 %dir %{_prefix}/lib/polkit-1
 %{_prefix}/lib/polkit-1/polkitd
+%{_tmpfilesdir}/polkit-tmpfiles.conf
 
 # see upstream docs for why these permissions are necessary
 %attr(4755,root,root) %{_bindir}/pkexec

--- a/data/polkit-tmpfiles.conf
+++ b/data/polkit-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /etc/polkit-1/rules.d 0750 root polkitd - -

--- a/meson.build
+++ b/meson.build
@@ -220,6 +220,18 @@ if enable_logind
 endif
 config_h.set('HAVE_LIBSYSTEMD', enable_logind)
 
+systemd_dep = dependency('systemd').found()
+if systemd_dep
+  tmpfiles_conf = files(
+    'data/polkit-tmpfiles.conf'
+  )
+
+  install_data(
+    tmpfiles_conf,
+    install_dir: pk_prefix / 'lib/tmpfiles.d/'
+  )
+endif
+
 config_h.set('HAVE_PIDFD_OPEN', cc.get_define('SYS_pidfd_open', prefix: '#include <sys/syscall.h>') != '')
 
 # User for running polkitd
@@ -404,6 +416,10 @@ output += '        Session tracking:         ' + session_tracking + '\n'
 if enable_logind
   output += '        systemdsystemunitdir:     ' + systemd_systemdsystemunitdir + '\n'
 endif
+if systemd_dep
+  output += '        systemdtmpfilesdir:       ' + pk_prefix + '/lib/tmpfiles.d' + '\n'
+endif
+
 output += '        polkitd user:             ' + polkitd_user + ' \n'
 if polkitd_uid != '-'
   output += '        polkitd UID:              ' + polkitd_uid + ' \n'


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
tmpfiles.d will automatically create the /etc/polkit-1/rules.d directory (and any non-existing directories on the path). After reboot, the directory contents will remain unchanged, and after removing the directory & rebooting, an empty directory will be created.

tmpfiles.d in fedora: https://docs.fedoraproject.org/en-US/packaging-guidelines/Tmpfiles.d/
tmpfiles.d manpage: https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html