### PR TITLE
Add new flag to check root user too in ChcekAuthorization

### DIFF
--- a/data/org.freedesktop.PolicyKit1.Authority.xml
+++ b/data/org.freedesktop.PolicyKit1.Authority.xml
@@ -111,6 +111,9 @@
       <annotation name="org.gtk.EggDBus.Flags.Member" value="AllowUserInteraction">
         <annotation name="org.gtk.EggDBus.DocString" value="If the #Subject can obtain the authorization through authentication, and an authentication agent is available, then attempt to do so. Note, this means that the org.freedesktop.PolicyKit1.Authority.CheckAuthorization() method will block while the user is being asked to authenticate."/>
       </annotation>
+      <annotation name="org.gtk.EggDBus.Flags.Member" value="AlwaysCheck">
+        <annotation name="org.gtk.EggDBus.DocString" value="Check access against policy even if the #Subject is the root user."/>
+      </annotation>
     </annotation>
 
     <!-- ---------------------------------------------------------------------------------------------------- -->

--- a/docs/polkit/docbook-interface-org.freedesktop.PolicyKit1.Authority.xml
+++ b/docs/polkit/docbook-interface-org.freedesktop.PolicyKit1.Authority.xml
@@ -78,7 +78,8 @@ This D-Bus interface is implemented by the <literal>/org/freedesktop/PolicyKit1/
           <programlisting>
 {
   None                 = 0x00000000,
-  AllowUserInteraction = 0x00000001
+  AllowUserInteraction = 0x00000001,
+  AlwaysCheck          = 0x00000002
 }
           </programlisting>
           <para>
@@ -98,6 +99,14 @@ No flags set.
     <listitem>
       <para>
 If the <link linkend="eggdbus-struct-Subject">Subject</link> can obtain the authorization through authentication, and an authentication agent is available, then attempt to do so. Note, this means that the <link linkend="eggdbus-method-org.freedesktop.PolicyKit1.Authority.CheckAuthorization">CheckAuthorization()</link> method will block while the user is being asked to authenticate.
+      </para>
+    </listitem>
+  </varlistentry>
+  <varlistentry id="eggdbus-constant-CheckAuthorizationFlags.AlwaysCheck" role="constant">
+    <term><literal>AlwaysCheck</literal></term>
+    <listitem>
+      <para>
+Check access against policy even if the <link linkend="eggdbus-struct-Subject">Subject</link> is the root user.
       </para>
     </listitem>
   </varlistentry>

--- a/src/polkit/polkitcheckauthorizationflags.h
+++ b/src/polkit/polkitcheckauthorizationflags.h
@@ -36,6 +36,7 @@ G_BEGIN_DECLS
  * @POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION: If the subject can obtain the authorization
  * through authentication, and an authentication agent is available, then attempt to do so. Note, this
  * means that the method used for checking authorization is likely to block for a long time.
+ * @POLKIT_CHECK_AUTHORIZATION_FLAGS_ALWAYS_CHECK: Check access against policy even for root user.
  *
  * Possible flags when checking authorizations.
  */
@@ -43,6 +44,7 @@ typedef enum
 {
   POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE = 0,
   POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION = (1<<0),
+  POLKIT_CHECK_AUTHORIZATION_FLAGS_ALWAYS_CHECK = (1<<1),
 } PolkitCheckAuthorizationFlags;
 
 G_END_DECLS

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -1130,7 +1130,7 @@ check_authorization_sync (PolkitBackendAuthority         *authority,
       goto out;
 
   /* special case: uid 0, root, is _always_ authorized for anything */
-  if (identity_is_root_user (user_of_subject))
+  if (!(flags & POLKIT_CHECK_AUTHORIZATION_FLAGS_ALWAYS_CHECK) && identity_is_root_user (user_of_subject))
     {
       result = polkit_authorization_result_new (TRUE, FALSE, NULL);
       goto out;


### PR DESCRIPTION
Currently if the subject has uid 0 a shortcut is taken and authorization is immediately granted, without checking against policies and rules. Add a flag that allows skipping this shortcut.

uid 0 can of course alter polkit's behaviour directly, so this is not so much a security feature, but more useful as a safety feature, so that when an action is disabled it cannot be accidentally performed by root, unless they really mean it and bypass polkit.

I intend to make use of this in logind, in the inhibitor functionality, to ensure even root has to drop an inhibitor lock before taking an action.
