### PR TITLE
Only instances affected by sessions change should call for CheckAuthorization

### DIFF
--- a/data/org.freedesktop.PolicyKit1.Authority.xml
+++ b/data/org.freedesktop.PolicyKit1.Authority.xml
@@ -431,7 +431,7 @@ Must match the effective UID of the caller of org.freedesktop.PolicyKit1.Authori
     <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <signal name="Changed">
-      <annotation name="org.gtk.EggDBus.DocString" value="This signal is emitted when actions and/or authorizations change"/>
+      <annotation name="org.gtk.EggDBus.DocString" value="This signal is emitted when actions, sessions and/or authorizations change, carrying information about the change."/>
     </signal>
 
   </interface>

--- a/src/polkit/polkitauthority.c
+++ b/src/polkit/polkitauthority.c
@@ -118,9 +118,13 @@ on_proxy_signal (GDBusProxy   *proxy,
 
   if (g_strcmp0 (signal_name, "Changed") == 0)
     {
-      if ((parameters != NULL) && g_variant_check_format_string(parameters, "(q)", FALSE ) )
+      if ((parameters != NULL) && g_variant_check_format_string(parameters, "(q)", FALSE))
       {
         g_variant_get(parameters, "(q)", &msg_mask);
+        if (msg_mask >= LAST_SIGNAL)
+        {
+          msg_mask = CHANGED_SIGNAL;  /* If signal not valid, we send generic "changed". */
+        }
         g_signal_emit (authority, signals[msg_mask], 0);
       }
       else
@@ -305,14 +309,14 @@ polkit_authority_class_init (PolkitAuthorityClass *klass)
    * Emitted when sessions change
    */
   signals[SESSIONS_CHANGED_SIGNAL] = g_signal_new ("sessions-changed",
-                                            POLKIT_TYPE_AUTHORITY,
-                                            G_SIGNAL_RUN_LAST,
-                                            0,                      /* class offset     */
-                                            NULL,                   /* accumulator      */
-                                            NULL,                   /* accumulator data */
-                                            g_cclosure_marshal_VOID__VOID,
-                                            G_TYPE_NONE,
-                                            0);
+                                                   POLKIT_TYPE_AUTHORITY,
+                                                   G_SIGNAL_RUN_LAST,
+                                                   0,                      /* class offset     */
+                                                   NULL,                   /* accumulator      */
+                                                   NULL,                   /* accumulator data */
+                                                   g_cclosure_marshal_VOID__VOID,
+                                                   G_TYPE_NONE,
+                                                   0);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/polkit/polkitauthority.c
+++ b/src/polkit/polkitauthority.c
@@ -84,6 +84,7 @@ static PolkitAuthority *the_authority = NULL;
 enum
 {
   CHANGED_SIGNAL,
+  SESSIONS_CHANGED_SIGNAL,
   LAST_SIGNAL,
 };
 
@@ -113,9 +114,19 @@ on_proxy_signal (GDBusProxy   *proxy,
                  gpointer      user_data)
 {
   PolkitAuthority *authority = POLKIT_AUTHORITY (user_data);
+  guint16 msg_mask;
+
   if (g_strcmp0 (signal_name, "Changed") == 0)
     {
-      g_signal_emit_by_name (authority, "changed");
+      if ((parameters != NULL) && g_variant_check_format_string(parameters, "(q)", FALSE ) )
+      {
+        g_variant_get(parameters, "(q)", &msg_mask);
+        g_signal_emit (authority, signals[msg_mask], 0);
+      }
+      else
+      {
+        g_signal_emit_by_name (authority, "changed");
+      }
     }
 }
 
@@ -287,6 +298,21 @@ polkit_authority_class_init (PolkitAuthorityClass *klass)
                                           g_cclosure_marshal_VOID__VOID,
                                           G_TYPE_NONE,
                                           0);
+  /**
+   * PolkitAuthority::sessions-changed:
+   * @authority: A #PolkitAuthority.
+   *
+   * Emitted when sessions change
+   */
+  signals[SESSIONS_CHANGED_SIGNAL] = g_signal_new ("sessions-changed",
+                                            POLKIT_TYPE_AUTHORITY,
+                                            G_SIGNAL_RUN_LAST,
+                                            0,                      /* class offset     */
+                                            NULL,                   /* accumulator      */
+                                            NULL,                   /* accumulator data */
+                                            g_cclosure_marshal_VOID__VOID,
+                                            G_TYPE_NONE,
+                                            0);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/polkit/polkitpermission.c
+++ b/src/polkit/polkitpermission.c
@@ -438,9 +438,9 @@ polkit_permission_initable_init (GInitable     *initable,
                     permission);
 
   g_signal_connect (permission->authority,
-                      "sessions-changed",
-                      G_CALLBACK (on_sessions_changed),
-                      permission);
+                    "sessions-changed",
+                    G_CALLBACK (on_sessions_changed),
+                    permission);
 
   result = polkit_authority_check_authorization_sync (permission->authority,
                                                       permission->subject,
@@ -502,21 +502,21 @@ static char *get_session_state()
   uid_t uid;
 
   if ( sd_pid_get_session(getpid(), &session) < 0 )
-  {
-    if ( sd_pid_get_owner_uid(getpid(), &uid) < 0)
     {
-      goto out;
+      if ( sd_pid_get_owner_uid(getpid(), &uid) < 0)
+        {
+          goto out;
+        }
+      if (sd_uid_get_display(uid, &session) < 0)
+        {
+          goto out;
+        }
     }
-    if (sd_uid_get_display(uid, &session) < 0)
-    {
-      goto out;
-    }
-  }
 
   if (session != NULL)
-  {
-    sd_session_get_state(session, &state);
-  }
+    {
+      sd_session_get_state(session, &state);
+    }
 out:
   g_free(session);
   return state;
@@ -555,20 +555,20 @@ static void on_sessions_changed (PolkitAuthority *authority,
 
   /* if we cannot tell the session state, we should do CheckAuthorization anyway */
   if ((new_session_state == NULL) || ( g_strcmp0(new_session_state, permission->session_state) != 0 ))
-  {
-    last_state = permission->session_state;
-    permission->session_state = new_session_state;
-    g_free(last_state);
+    {
+      last_state = permission->session_state;
+      permission->session_state = new_session_state;
+      g_free(last_state);
 
-    polkit_authority_check_authorization (permission->authority,
-                                      permission->subject,
-                                      permission->action_id,
-                                      NULL, /* PolkitDetails */
-                                      POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE,
-                                      NULL /* cancellable */,
-                                      changed_check_cb,
-                                      g_object_ref (permission));
-  }
+      polkit_authority_check_authorization (permission->authority,
+                                            permission->subject,
+                                            permission->action_id,
+                                            NULL, /* PolkitDetails */
+                                            POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE,
+                                            NULL /* cancellable */,
+                                            changed_check_cb,
+                                            g_object_ref (permission));
+    }
 #else
   on_authority_changed(authority, user_data);  /* TODO: resolve the "too many session signals" issue for non-systemd systems later */
 #endif

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -80,14 +80,14 @@ polkit_backend_authority_class_init (PolkitBackendAuthorityClass *klass)
                                           G_TYPE_NONE,
                                           0);
   signals[SESSIONS_CHANGED_SIGNAL] = g_signal_new ("sessions-changed",
-                                          POLKIT_BACKEND_TYPE_AUTHORITY,
-                                          G_SIGNAL_RUN_LAST,
-                                          G_STRUCT_OFFSET (PolkitBackendAuthorityClass, changed),
-                                          NULL,                   /* accumulator      */
-                                          NULL,                   /* accumulator data */
-                                          g_cclosure_marshal_VOID__VOID,
-                                          G_TYPE_NONE,
-                                          0);
+                                                   POLKIT_BACKEND_TYPE_AUTHORITY,
+                                                   G_SIGNAL_RUN_LAST,
+                                                   G_STRUCT_OFFSET (PolkitBackendAuthorityClass, changed),
+                                                   NULL,                   /* accumulator      */
+                                                   NULL,                   /* accumulator data */
+                                                   g_cclosure_marshal_VOID__VOID,
+                                                   G_TYPE_NONE,
+                                                   0);
 }
 
 /**
@@ -575,7 +575,7 @@ static void
 on_authority_changed (PolkitBackendAuthority *authority,
                       gpointer                user_data)
 {
-  guint16 msg_mask = 0;
+  guint16 msg_mask;
 
   msg_mask = (guint16) CHANGED_SIGNAL;
   changed_dbus_call_handler(authority, user_data, msg_mask);
@@ -586,7 +586,7 @@ static void
 on_sessions_changed (PolkitBackendAuthority *authority,
                       gpointer                user_data)
 {
-  guint16 msg_mask = 0;
+  guint16 msg_mask;
 
   msg_mask = (guint16) SESSIONS_CHANGED_SIGNAL;
   changed_dbus_call_handler(authority, user_data, msg_mask);
@@ -1439,9 +1439,9 @@ polkit_backend_authority_register (PolkitBackendAuthority   *authority,
                                                    server);
 
   server->authority_session_monitor_signaller = g_signal_connect (server->authority,
-                                                   "sessions-changed",
-                                                   G_CALLBACK (on_sessions_changed),
-                                                   server);
+                                                                  "sessions-changed",
+                                                                  G_CALLBACK (on_sessions_changed),
+                                                                  server);
 
   return server;
 

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -284,7 +284,7 @@ on_session_monitor_changed (PolkitBackendSessionMonitor *monitor,
                             gpointer                     user_data)
 {
   PolkitBackendInteractiveAuthority *authority = POLKIT_BACKEND_INTERACTIVE_AUTHORITY (user_data);
-  g_signal_emit_by_name (authority, "changed");
+  g_signal_emit_by_name (authority, "sessions-changed");
 }
 
 static void


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
Currently, every time the systemd-logind monitor sends a notification about change in sessions, all instances of PolkitPermission (and probably other classes using PolkitAuthority) send CheckAuthorization to the daemon even though their session is not affected. This hogs the cpu needlessly, because ALL programs/applets in ALL instances for ALL users send CheckAuthorization, making each such request even repeated. This PR adds recognition of a change in sessions, adds it to the "Changed" dbus signal as a parameter, and on the client side of polkit (i.e. PolkitAuthority) enables to react accordingly. This enables PolkitPermission to assess whether the session change affects just the objects in affected sessions.


## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
The problem can be observed if running gnome-shell, then just logging in (in a terminal, over ssh, etc.) and watching the output in dbus-monitor:  
`sudo busctl monitor org.freedesktop.PolicyKit1 | grep -e "PolicyKit1.*Changed\|CheckAuthorization`
Here, on just one log-in, more than one (usually three) "Changed" signals are generated (three events sent by logind monitor), each of which starts huge "CheckAuthorization" train.  
With the fix, the CheckAuthorization is triggered only if the session really changed (e.g. user logged in on a new tty and gnome-shell's session goes from "active" to "online" state).