### PR TITLE
Refactor config.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,7 @@ top_inc = include_directories('.')
 
 cc = meson.get_compiler('c')
 
-config_h = configuration_data()
+config_data = configuration_data()
 
 # defines
 set_defines = [
@@ -79,11 +79,11 @@ set_defines = [
 ]
 
 foreach define: set_defines
-  config_h.set_quoted(define[0], define[1])
+  config_data.set_quoted(define[0], define[1])
 endforeach
 
 # Globally define_GNU_SOURCE and therefore enable the GNU extensions
-config_h.set('_GNU_SOURCE', true)
+config_data.set('_GNU_SOURCE', true)
 
 # functions
 check_functions = [
@@ -93,19 +93,17 @@ check_functions = [
 ]
 
 foreach func: check_functions
-  config_h.set('HAVE_' + func.to_upper(), cc.has_function(func))
+  config_data.set('HAVE_' + func.to_upper(), cc.has_function(func))
 endforeach
 
-# compiler flags
-common_c_flags = [
+compiler_common_flags = []
+compiler_c_flags = [
   # FIXME: this should go as 'c_std=c99' in project's default_options.
   #        https://github.com/mesonbuild/meson/issues/1889
   #        https://github.com/mesonbuild/meson/pull/6729
   '-std=c99',
-  '-DHAVE_CONFIG_H',
 ]
-compiler_flags = []
-compiler_c_flags = []
+compiler_cpp_flags = []
 
 if get_option('buildtype').contains('debug')
   compiler_c_flags += cc.get_supported_arguments([
@@ -120,8 +118,6 @@ if get_option('buildtype').contains('debug')
     '-Wstrict-prototypes',
   ])
 endif
-
-add_project_arguments(common_c_flags + compiler_c_flags, language: 'c')
 
 glib_req_version = '>= 2.30.0'
 
@@ -151,13 +147,13 @@ if js_engine == 'duktape'
   libm_dep = cc.find_library('m')
   thread_dep = dependency('threads')
   func = 'pthread_condattr_setclock'
-  config_h.set('HAVE_' + func.to_upper(), cc.has_function(func, prefix : '#include <pthread.h>'))
+  config_data.set('HAVE_' + func.to_upper(), cc.has_function(func, prefix : '#include <pthread.h>'))
 elif js_engine == 'mozjs'
   js_dep = dependency('mozjs-115')
 
   _system = host_machine.system().to_lower()
   if _system.contains('freebsd')
-    config_h.set('__BSD_VISIBLE', 1)
+    config_data.set('__BSD_VISIBLE', 1)
   endif
 endif
 
@@ -172,12 +168,12 @@ endif
 
 # check OS
 host_system = host_machine.system()
-config_h.set('HAVE_' + host_system.to_upper(), true)
+config_data.set('HAVE_' + host_system.to_upper(), true)
 
 # Check whether setnetgrent has a return value
-config_h.set('HAVE_NETGROUP_H', cc.has_header('netgroup.h'))
+config_data.set('HAVE_NETGROUP_H', cc.has_header('netgroup.h'))
 
-if config_h.get('HAVE_SETNETGRENT', false)
+if config_data.get('HAVE_SETNETGRENT', false)
   setnetgrent_return_src = '''
     #include <stddef.h>
     #ifdef HAVE_NETGROUP_H
@@ -190,7 +186,7 @@ if config_h.get('HAVE_SETNETGRENT', false)
     };
   '''
 
-  config_h.set('HAVE_SETNETGRENT_RETURN', cc.compiles(setnetgrent_return_src, name: 'setnetgrent return support'))
+  config_data.set('HAVE_SETNETGRENT_RETURN', cc.compiles(setnetgrent_return_src, name: 'setnetgrent return support'))
 endif
 
 # Select wether to use logind, elogind or ConsoleKit for session tracking
@@ -214,11 +210,11 @@ if enable_logind
   endif
 
   func = 'sd_uid_get_display'
-  config_h.set10('HAVE_' + func.to_upper(), cc.has_function(func, dependencies: logind_dep))
+  config_data.set10('HAVE_' + func.to_upper(), cc.has_function(func, dependencies: logind_dep))
   func = 'sd_pidfd_get_session'
-  config_h.set10('HAVE_' + func.to_upper(), cc.has_function(func, dependencies: logind_dep))
+  config_data.set10('HAVE_' + func.to_upper(), cc.has_function(func, dependencies: logind_dep))
 endif
-config_h.set('HAVE_LIBSYSTEMD', enable_logind)
+config_data.set('HAVE_LIBSYSTEMD', enable_logind)
 
 systemd_dep = dependency('systemd').found()
 if systemd_dep
@@ -232,14 +228,14 @@ if systemd_dep
   )
 endif
 
-config_h.set('HAVE_PIDFD_OPEN', cc.get_define('SYS_pidfd_open', prefix: '#include <sys/syscall.h>') != '')
+config_data.set('HAVE_PIDFD_OPEN', cc.get_define('SYS_pidfd_open', prefix: '#include <sys/syscall.h>') != '')
 
 # User for running polkitd
 polkitd_user = get_option('polkitd_user')
-config_h.set_quoted('POLKITD_USER', polkitd_user)
+config_data.set_quoted('POLKITD_USER', polkitd_user)
 
 polkitd_uid = get_option('polkitd_uid')
-config_h.set('POLKITD_UID', polkitd_uid)
+config_data.set('POLKITD_UID', polkitd_uid)
 
 # Select which authentication framework to use
 auth_deps = []
@@ -265,7 +261,7 @@ if enable_pam
   # FIXME: Not necessary anymore?
   if cc.compiles(pam_strerror_src.format('pam_handle_t *pamh = 0; char *s = pam_strerror(pamh, PAM_SUCCESS);'))
     # FIXME: unused?
-    config_h.set('PAM_STRERROR_TWO_ARGS', true)
+    config_data.set('PAM_STRERROR_TWO_ARGS', true)
   else
     message('how to call pam_strerror: ' + cc.compiles(pam_strerror_src.format('char *s = pam_strerror(PAM_SUCCESS);')).to_string('1', 'unknown'))
   endif
@@ -286,7 +282,7 @@ if enable_pam
 elif auth_fw == 'shadow'
   auth_deps += cc.find_library('crypt')
 endif
-config_h.set('POLKIT_AUTHFW_' + auth_fw.to_upper(), true)
+config_data.set('POLKIT_AUTHFW_' + auth_fw.to_upper(), true)
 
 # FIXME: sigtimedwait is not used anywhere?
 '''
@@ -367,6 +363,16 @@ if enable_introspection
   dependency('gobject-introspection-1.0', version: '>= 0.6.2')
 endif
 
+configure_file(
+  output: 'config.h',
+  configuration: config_data,
+)
+
+compiler_common_flags += ['-include', 'config.h']
+
+add_project_arguments(compiler_common_flags + compiler_c_flags, language: 'c')
+add_project_arguments(compiler_common_flags + compiler_cpp_flags, language: 'cpp')
+
 content_files = files('COPYING')
 
 subdir('actions')
@@ -379,12 +385,6 @@ enable_tests = get_option('tests')
 if enable_tests
   subdir('test')
 endif
-
-configure_file(
-  output: 'config.h',
-  configuration: config_h,
-)
-
 
 if not libs_only
   meson.add_install_script(

--- a/src/examples/cancel.c
+++ b/src/examples/cancel.c
@@ -32,7 +32,6 @@
  * authentication dialog is removed.
  */
 
-#include "config.h"
 #include <polkit/polkit.h>
 
 static gboolean

--- a/src/examples/frobnicate.c
+++ b/src/examples/frobnicate.c
@@ -19,8 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
-
 #include <glib.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/polkit/polkitactiondescription.c
+++ b/src/polkit/polkitactiondescription.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include "polkitimplicitauthorization.h"
 #include "polkitactiondescription.h"

--- a/src/polkit/polkitauthority.c
+++ b/src/polkit/polkitauthority.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include "polkitauthorizationresult.h"
 #include "polkitcheckauthorizationflags.h"
 #include "polkitauthority.h"

--- a/src/polkit/polkitauthorityfeatures.c
+++ b/src/polkit/polkitauthorityfeatures.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include "polkitcheckauthorizationflags.h"
 #include "polkitprivate.h"
 

--- a/src/polkit/polkitauthorizationresult.c
+++ b/src/polkit/polkitauthorizationresult.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include "polkitauthorizationresult.h"
 #include "polkitdetails.h"
 #include "polkitprivate.h"

--- a/src/polkit/polkitcheckauthorizationflags.c
+++ b/src/polkit/polkitcheckauthorizationflags.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include "polkitcheckauthorizationflags.h"
 #include "polkitprivate.h"
 

--- a/src/polkit/polkitdetails.c
+++ b/src/polkit/polkitdetails.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include "polkitimplicitauthorization.h"
 #include "polkitdetails.h"

--- a/src/polkit/polkiterror.c
+++ b/src/polkit/polkiterror.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include "polkiterror.h"
 #include "polkitprivate.h"
 

--- a/src/polkit/polkitidentity.c
+++ b/src/polkit/polkitidentity.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 
 #include "polkitidentity.h"

--- a/src/polkit/polkitimplicitauthorization.c
+++ b/src/polkit/polkitimplicitauthorization.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 
 #include "polkitimplicitauthorization.h"

--- a/src/polkit/polkitpermission.c
+++ b/src/polkit/polkitpermission.c
@@ -20,10 +20,6 @@
  *         David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #ifdef HAVE_LIBSYSTEMD
 #  include <systemd/sd-login.h>
 #endif

--- a/src/polkit/polkitsubject.c
+++ b/src/polkit/polkitsubject.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include <stdio.h>
 

--- a/src/polkit/polkitsystembusname.c
+++ b/src/polkit/polkitsystembusname.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include <gio/gunixfdlist.h>
 #include "polkitsystembusname.h"

--- a/src/polkit/polkittemporaryauthorization.c
+++ b/src/polkit/polkittemporaryauthorization.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include "polkitimplicitauthorization.h"
 #include "polkittemporaryauthorization.h"

--- a/src/polkit/polkitunixgroup.c
+++ b/src/polkit/polkitunixgroup.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include <grp.h>
 #include <errno.h>

--- a/src/polkit/polkitunixnetgroup.c
+++ b/src/polkit/polkitunixnetgroup.c
@@ -20,10 +20,6 @@
  * Author: Nikki VonHollen <vonhollen@google.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include <errno.h>
 #include "polkitunixnetgroup.h"

--- a/src/polkit/polkitunixprocess.c
+++ b/src/polkit/polkitunixprocess.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <sys/types.h>
 #ifdef HAVE_FREEBSD
 #include <sys/param.h>

--- a/src/polkit/polkitunixsession-systemd.c
+++ b/src/polkit/polkitunixsession-systemd.c
@@ -19,10 +19,6 @@
  * Author: Matthias Clasen
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <stdlib.h>
 #include <string.h>
 #include "polkitunixsession.h"

--- a/src/polkit/polkitunixsession.c
+++ b/src/polkit/polkitunixsession.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include "polkitunixsession.h"
 #include "polkitsubject.h"

--- a/src/polkit/polkitunixuser.c
+++ b/src/polkit/polkitunixuser.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include <pwd.h>
 #include <errno.h>

--- a/src/polkitagent/polkitagenthelper-bsdauth.c
+++ b/src/polkitagent/polkitagenthelper-bsdauth.c
@@ -23,7 +23,6 @@
  *          David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include "polkitagenthelperprivate.h"
 
 #include <stdio.h>

--- a/src/polkitagent/polkitagenthelper-pam.c
+++ b/src/polkitagent/polkitagenthelper-pam.c
@@ -19,7 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include "polkitagenthelperprivate.h"
 
 #include <stdio.h>

--- a/src/polkitagent/polkitagenthelper-shadow.c
+++ b/src/polkitagent/polkitagenthelper-shadow.c
@@ -22,7 +22,6 @@
  *          David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include "polkitagenthelperprivate.h"
 
 #include <stdio.h>

--- a/src/polkitagent/polkitagenthelperprivate.c
+++ b/src/polkitagent/polkitagenthelperprivate.c
@@ -20,7 +20,6 @@
  *          Andrew Psaltis <ampsaltis@gmail.com>
  */
 
-#include "config.h"
 #include "polkitagenthelperprivate.h"
 #include <stdio.h>
 #include <string.h>

--- a/src/polkitagent/polkitagentlistener.c
+++ b/src/polkitagent/polkitagentlistener.c
@@ -19,8 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
-
 #include <polkit/polkitprivate.h>
 
 #include "polkitagentlistener.h"

--- a/src/polkitagent/polkitagentsession.c
+++ b/src/polkitagent/polkitagentsession.c
@@ -49,7 +49,6 @@
  * be emitted with the @gained_authorization paramter set to %FALSE.
  */
 
-#include "config.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/polkitagent/polkitagenttextlistener.c
+++ b/src/polkitagent/polkitagenttextlistener.c
@@ -19,8 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
-
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/polkitbackend/polkitbackendactionlookup.c
+++ b/src/polkitbackend/polkitbackendactionlookup.c
@@ -19,7 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include <errno.h>
 #include <pwd.h>
 #include <string.h>

--- a/src/polkitbackend/polkitbackendactionpool.c
+++ b/src/polkitbackend/polkitbackendactionpool.c
@@ -19,7 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include <errno.h>
 #include <pwd.h>
 #include <string.h>

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -19,7 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include <errno.h>
 #include <pwd.h>
 #include <string.h>

--- a/src/polkitbackend/polkitbackendcommon.h
+++ b/src/polkitbackend/polkitbackendcommon.h
@@ -26,7 +26,6 @@
 #ifndef __POLKIT_BACKEND_COMMON_H
 #define __POLKIT_BACKEND_COMMON_H
 
-#include "config.h"
 #include <sys/wait.h>
 #include <errno.h>
 #include <pwd.h>

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -19,7 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include <errno.h>
 #include <pwd.h>
 #include <grp.h>

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -1487,10 +1487,10 @@ authentication_agent_generate_cookie (AuthenticationAgent *agent)
   GString *buf = g_string_new ("");
 
   g_string_append (buf, agent->cookie_prefix);
-  
+
   g_string_append_c (buf, '-');
   agent->cookie_serial++;
-  g_string_append_printf (buf, "%" G_GUINT64_FORMAT, 
+  g_string_append_printf (buf, "%" G_GUINT64_FORMAT,
                           agent->cookie_serial);
   g_string_append_c (buf, '-');
   append_rand_u128_str (buf, agent->cookie_pool);
@@ -1684,7 +1684,7 @@ authentication_agent_new (guint64      serial,
     g_rand_free (agent_private_rand);
 
     agent->cookie_prefix = g_string_free (cookie_prefix, FALSE);
-    
+
     /* And a newly seeded pool for per-session cookies */
     agent->cookie_pool = g_rand_new ();
   }
@@ -1786,7 +1786,7 @@ get_authentication_session_for_uid_and_cookie (PolkitBackendInteractiveAuthority
        * due to wrapping, that the cookie used is matched to the user
        * who called AuthenticationAgentResponse2.  See
        * http://lists.freedesktop.org/archives/polkit-devel/2015-June/000425.html
-       * 
+       *
        * Except if the legacy AuthenticationAgentResponse is invoked,
        * we don't know the uid and hence use -1.  Continue to support
        * the old behavior for backwards compatibility, although everyone

--- a/src/polkitbackend/polkitbackendsessionmonitor-systemd.c
+++ b/src/polkitbackend/polkitbackendsessionmonitor-systemd.c
@@ -19,7 +19,6 @@
  * Author: Matthias Clasen
  */
 
-#include "config.h"
 #include <errno.h>
 #include <pwd.h>
 #include <grp.h>

--- a/src/polkitbackend/polkitbackendsessionmonitor.c
+++ b/src/polkitbackend/polkitbackendsessionmonitor.c
@@ -19,7 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include <errno.h>
 #include <pwd.h>
 #include <grp.h>

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -19,8 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
-
 #include <signal.h>
 #include <stdlib.h>
 

--- a/src/programs/pkaction.c
+++ b/src/programs/pkaction.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <glib/gi18n.h>

--- a/src/programs/pkcheck.c
+++ b/src/programs/pkcheck.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <glib/gi18n.h>

--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <string.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -202,7 +202,7 @@ open_session (const gchar *user_to_auth,
       for (n = 0; envlist[n]; n++)
 	{
 	  const char *envitem = envlist[n];
-	  
+
 	  if (g_str_has_prefix (envitem, "XDG_RUNTIME_DIR="))
 	    {
 	      const char *eq = strchr (envitem, '=');
@@ -1031,7 +1031,7 @@ main (int argc, char *argv[])
 
   /* change to home directory */
   if (!opt_keep_cwd)
-    {  
+    {
       if (chdir (pw->pw_dir) != 0)
         {
           g_printerr ("Error changing to home directory %s: %s\n", pw->pw_dir, g_strerror (errno));

--- a/src/programs/pkttyagent.c
+++ b/src/programs/pkttyagent.c
@@ -19,10 +19,6 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>

--- a/test/polkitbackend/test-polkitbackendjsauthority.c
+++ b/test/polkitbackend/test-polkitbackendjsauthority.c
@@ -21,7 +21,6 @@
  *         David Zeuthen <davidz@redhat.com>
  */
 
-#include "config.h"
 #include "glib.h"
 
 #include <locale.h>


### PR DESCRIPTION
I simplified the handling of `config.h`.
Instead of having `#include "config.h"` in every file, we can use the compiler's `-include` option to do that for us.

I had to bump the meson version requirement to >=1.4.0 to use the `file.full_path()` API.