### PR TITLE
Fix duplicate feature test macros

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,9 +83,6 @@ foreach define: set_defines
   config_data.set_quoted(define[0], define[1])
 endforeach
 
-# Globally define_GNU_SOURCE and therefore enable the GNU extensions
-config_data.set('_GNU_SOURCE', true)
-
 # functions
 check_functions = [
   'clearenv',
@@ -97,7 +94,9 @@ foreach func: check_functions
   config_data.set('HAVE_' + func.to_upper(), cc.has_function(func))
 endforeach
 
-compiler_common_flags = []
+compiler_common_flags = [
+  '-D_GNU_SOURCE',
+]
 compiler_c_flags = []
 compiler_cpp_flags = []
 

--- a/src/polkitbackend/meson.build
+++ b/src/polkitbackend/meson.build
@@ -29,8 +29,6 @@ c_flags = [
   '-D_POLKIT_BACKEND_COMPILATION',
   '-DPACKAGE_DATA_DIR="@0@"'.format(pk_prefix / pk_datadir),
   '-DPACKAGE_SYSCONF_DIR="@0@"'.format(pk_prefix / pk_sysconfdir),
-  '-D_XOPEN_SOURCE=700',
-  '-D_GNU_SOURCE=1',
 ]
 
 if js_engine == 'duktape'


### PR DESCRIPTION
I removed feature test macro definitions (i.e `_GNU_SOURCE`/`_XOPEN_SOURCE`) from polkitbackend because `_GNU_SOURCE` is already defined in the root meson.build.
Explicitly defining `_XOPEN_SOURCE` is redundant because `_GNU_SOURCE` implies `_XOPEN_SOURCE 700` (according to the comments in glibc's `features.h`)

Depends on #454