### PR TITLE
ci: bump the CodeQL GH Actions worker to Ubuntu Noble

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
     concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install dependencies
       if: ${{ matrix.language == 'c-cpp' }}
       run: |
-        sudo add-apt-repository -y --no-update --enable-source
+        sudo sed -i 's/^Types: deb/Types: deb deb-src/g' /etc/apt/sources.list.d/*.sources
         sudo apt update
         sudo apt build-dep -y policykit-1
         # polkit in Ubuntu Jammy (ATTOW) doesn't have the latest build dependencies yet


### PR DESCRIPTION
So we get newer meson, which is required since 60673b8:
