### PR TITLE
Dont hardcode path to config.h

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,12 @@ jobs:
         sudo apt update
         sudo apt build-dep -y policykit-1
         # polkit in Ubuntu Jammy (ATTOW) doesn't have the latest build dependencies yet
-        sudo apt install -y duktape-dev meson
+        sudo apt install -y duktape-dev python3-pip
+
+        # Ubuntu 22.04 ships only meson 1.3.4 (ATTOW), so install a newer one via pip
+        dpkg-query -W meson && sudo apt remove -y meson
+        sudo pip3 install 'meson>=1.4.0'
+        sudo meson --version
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/meson.build
+++ b/meson.build
@@ -375,12 +375,12 @@ if gettext
   config_data.set('ENABLE_GETTEXT', 1)
 endif
 
-configure_file(
+config_h = configure_file(
   output: 'config.h',
   configuration: config_data,
 )
 
-compiler_common_flags += ['-include', 'config.h']
+compiler_common_flags += ['-include', config_h.full_path()]
 
 add_project_arguments(compiler_common_flags + compiler_c_flags, language: 'c')
 add_project_arguments(compiler_common_flags + compiler_cpp_flags, language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
     'c_std=c99',
     'cpp_std=c++17',
   ],
-  meson_version: '>= 0.63.0',
+  meson_version: '>= 1.4.0',
 )
 
 pk_version = meson.project_version()


### PR DESCRIPTION
Split from #454 as requested.

This is a minor change that requires meson >= 1.4.0, which isn't available in Fedora 39.
F39 becomes EOL on 2024-11-12.