### PR TITLE
ci: actually use the current reference in group ID

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       security-events: write
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.ref }}-${{ matrix.language }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.language }}
       cancel-in-progress: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
There's no `matrix.ref`, only `github.ref`. Use that to make sure we don't kill workflow jobs from other PRs.

Followup for b3a3a256.

Resolves: #467
