### PR TITLE
Log levels implementation

### DIFF
--- a/data/polkit.service.in
+++ b/data/polkit.service.in
@@ -8,7 +8,7 @@ BusName=org.freedesktop.PolicyKit1
 CapabilityBoundingSet=CAP_SETUID CAP_SETGID
 DeviceAllow=/dev/null rw
 DevicePolicy=strict
-ExecStart=@libprivdir@/polkitd --no-debug
+ExecStart=@libprivdir@/polkitd --no-debug --log-level=3
 User=@polkitd_user@
 LimitMEMLOCK=0
 LockPersonality=yes

--- a/data/polkit.service.in
+++ b/data/polkit.service.in
@@ -8,7 +8,7 @@ BusName=org.freedesktop.PolicyKit1
 CapabilityBoundingSet=CAP_SETUID CAP_SETGID
 DeviceAllow=/dev/null rw
 DevicePolicy=strict
-ExecStart=@libprivdir@/polkitd --no-debug --log-level=3
+ExecStart=@libprivdir@/polkitd --no-debug --log-level=2
 User=@polkitd_user@
 LimitMEMLOCK=0
 LockPersonality=yes

--- a/data/polkit.service.in
+++ b/data/polkit.service.in
@@ -8,7 +8,7 @@ BusName=org.freedesktop.PolicyKit1
 CapabilityBoundingSet=CAP_SETUID CAP_SETGID
 DeviceAllow=/dev/null rw
 DevicePolicy=strict
-ExecStart=@libprivdir@/polkitd --no-debug --log-level=2
+ExecStart=@libprivdir@/polkitd --no-debug --log-level=5
 User=@polkitd_user@
 LimitMEMLOCK=0
 LockPersonality=yes

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -52,6 +52,7 @@ enum
 };
 
 static guint signals[LAST_SIGNAL] = {0};
+static guint polkit_authority_log_level = LOG_LEVEL_ERROR;
 
 G_DEFINE_ABSTRACT_TYPE (PolkitBackendAuthority, polkit_backend_authority, G_TYPE_OBJECT);
 
@@ -1561,6 +1562,7 @@ _color_get (_Color color)
 
 void
 polkit_backend_authority_log (PolkitBackendAuthority *authority,
+                              const guint message_log_level,
                               const gchar *format,
                               ...)
 {
@@ -1571,6 +1573,8 @@ polkit_backend_authority_log (PolkitBackendAuthority *authority,
   gchar *message;
   va_list var_args;
 
+
+  g_return_if_fail (message_log_level <= polkit_authority_log_level);
   g_return_if_fail (POLKIT_BACKEND_IS_AUTHORITY (authority));
 
   va_start (var_args, format);
@@ -1590,4 +1594,13 @@ polkit_backend_authority_log (PolkitBackendAuthority *authority,
            message);
 
   g_free (message);
+}
+
+void
+polkit_backend_authority_set_log_level (const guint level)
+  {
+    if (level <= LOG_LEVEL_VERBOSE)
+    {
+        polkit_authority_log_level = level;
+    }
 }

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -1600,10 +1600,10 @@ polkit_backend_authority_log (PolkitBackendAuthority *authority,
 }
 
 void
-polkit_backend_authority_set_log_level (const guint level)
+polkit_backend_authority_set_log_level (const gint level)
   {
-    if (level <= LOG_LEVEL_VERBOSE)
+    if ((level >= 0) && (level <= LOG_LEVEL_VERBOSE))
     {
-        polkit_authority_log_level = level;
+        polkit_authority_log_level = (guint) level;
     }
 }

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -52,7 +52,7 @@ enum
 };
 
 static guint signals[LAST_SIGNAL] = {0};
-static guint polkit_authority_log_level = LOG_LEVEL_ERROR;
+static guint polkit_authority_log_level;
 
 G_DEFINE_ABSTRACT_TYPE (PolkitBackendAuthority, polkit_backend_authority, G_TYPE_OBJECT);
 
@@ -1602,7 +1602,7 @@ polkit_backend_authority_log (PolkitBackendAuthority *authority,
 void
 polkit_backend_authority_set_log_level (const gint level)
   {
-    if ((level >= 0) && (level <= LOG_LEVEL_VERBOSE))
+    if ((level >= 0) && (level <= LOG_LEVEL_DEBUG))
     {
         polkit_authority_log_level = (guint) level;
     }

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -1573,8 +1573,11 @@ polkit_backend_authority_log (PolkitBackendAuthority *authority,
   gchar *message;
   va_list var_args;
 
+  if (message_log_level > polkit_authority_log_level)
+  {
+	  return;
+  }
 
-  g_return_if_fail (message_log_level <= polkit_authority_log_level);
   g_return_if_fail (POLKIT_BACKEND_IS_AUTHORITY (authority));
 
   va_start (var_args, format);

--- a/src/polkitbackend/polkitbackendauthority.h
+++ b/src/polkitbackend/polkitbackendauthority.h
@@ -225,7 +225,7 @@ void     polkit_backend_authority_log (PolkitBackendAuthority *authority,
                                        ...);
 
 void
-polkit_backend_authority_set_log_level (const guint level);
+polkit_backend_authority_set_log_level (const gint level);
 
 GList   *polkit_backend_authority_enumerate_actions         (PolkitBackendAuthority    *authority,
                                                              PolkitSubject             *caller,

--- a/src/polkitbackend/polkitbackendauthority.h
+++ b/src/polkitbackend/polkitbackendauthority.h
@@ -52,6 +52,14 @@ struct _PolkitBackendAuthority
   GObject parent_instance;
 };
 
+enum
+{
+	LOG_LEVEL_ERROR,	// log errors only
+	LOG_LEVEL_WARNING,	// errors and warnings
+	LOG_LEVEL_NOTIFY,   // like "all" interesting
+	LOG_LEVEL_VERBOSE  //  log every heartbeat, cough and fallen leaf. This is unlikely, but for future's sake...
+};
+
 /**
  * PolkitBackendAuthorityClass:
  * @parent_class: The parent class.

--- a/src/polkitbackend/polkitbackendauthority.h
+++ b/src/polkitbackend/polkitbackendauthority.h
@@ -52,12 +52,19 @@ struct _PolkitBackendAuthority
   GObject parent_instance;
 };
 
+/**
+ * Log levels aligned with those used in syslog and LogControl
+ */
 enum
 {
-	LOG_LEVEL_ERROR,	// log errors only
-	LOG_LEVEL_WARNING,	// errors and warnings
-	LOG_LEVEL_NOTIFY,   // like "all" interesting
-	LOG_LEVEL_VERBOSE  //  log every heartbeat, cough and fallen leaf. This is unlikely, but for future's sake...
+	LOG_LEVEL_EMERG,
+	LOG_LEVEL_ALERT,
+	LOG_LEVEL_CRIT,
+	LOG_LEVEL_ERROR,
+	LOG_LEVEL_WARNING,
+	LOG_LEVEL_NOTICE,
+	LOG_LEVEL_INFO,
+	LOG_LEVEL_DEBUG
 };
 
 /**

--- a/src/polkitbackend/polkitbackendauthority.h
+++ b/src/polkitbackend/polkitbackendauthority.h
@@ -220,8 +220,12 @@ const gchar             *polkit_backend_authority_get_version  (PolkitBackendAut
 PolkitAuthorityFeatures  polkit_backend_authority_get_features (PolkitBackendAuthority *authority);
 
 void     polkit_backend_authority_log (PolkitBackendAuthority *authority,
+                                       const guint message_log_level,
                                        const gchar *format,
                                        ...);
+
+void
+polkit_backend_authority_set_log_level (const guint level);
 
 GList   *polkit_backend_authority_enumerate_actions         (PolkitBackendAuthority    *authority,
                                                              PolkitSubject             *caller,

--- a/src/polkitbackend/polkitbackendcommon.c
+++ b/src/polkitbackend/polkitbackendcommon.c
@@ -349,7 +349,7 @@ polkit_backend_common_on_dir_monitor_changed (GFileMonitor     *monitor,
            event_type == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT))
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_NOTIFY,
+                                        LOG_LEVEL_NOTICE,
                                         "Reloading rules");
           polkit_backend_common_reload_scripts (authority);
         }

--- a/src/polkitbackend/polkitbackendcommon.c
+++ b/src/polkitbackend/polkitbackendcommon.c
@@ -349,6 +349,7 @@ polkit_backend_common_on_dir_monitor_changed (GFileMonitor     *monitor,
            event_type == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT))
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_NOTIFY,
                                         "Reloading rules");
           polkit_backend_common_reload_scripts (authority);
         }

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -114,7 +114,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       GDir *dir = NULL;
 
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                    LOG_LEVEL_NOTIFY,
+                                    LOG_LEVEL_NOTICE,
                                     "Loading rules from directory %s",
                                     dir_name);
 
@@ -151,13 +151,13 @@ load_scripts (PolkitBackendJsAuthority  *authority)
           continue;
       num_scripts++;
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                      LOG_LEVEL_VERBOSE,
+                                      LOG_LEVEL_DEBUG,
                                       "Loaded and executed script in file %s",
                                       filename);
     }
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "Finished loading, compiling and executing %d rules",
                                 num_scripts);
   g_list_free_full (files, g_free);
@@ -180,7 +180,7 @@ polkit_backend_common_reload_scripts (PolkitBackendJsAuthority *authority)
   duk_call_prop (cx, 0, 0);
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "Collecting garbage unconditionally...");
 
   load_scripts (authority);

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -150,6 +150,10 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       if (!execute_script_with_runaway_killer(authority, filename))
           continue;
       num_scripts++;
+      polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                      LOG_LEVEL_VERBOSE,
+                                      "Loaded and executed script in file %s",
+                                      filename);
     }
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -86,6 +86,7 @@ static void report_error (void     *udata,
 {
     PolkitBackendJsAuthority *authority = udata;
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "fatal Duktape JS backend error: %s",
                                   (msg ? msg : "no message"));
 }
@@ -113,6 +114,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       GDir *dir = NULL;
 
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_NOTIFY,
                                     "Loading rules from directory %s",
                                     dir_name);
 
@@ -122,6 +124,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       if (dir == NULL)
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_ERROR,
                                         "Error opening rules directory: %s (%s, %d)",
                                         error->message, g_quark_to_string (error->domain), error->code);
           g_clear_error (&error);
@@ -150,6 +153,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
     }
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "Finished loading, compiling and executing %d rules",
                                 num_scripts);
   g_list_free_full (files, g_free);
@@ -163,6 +167,7 @@ polkit_backend_common_reload_scripts (PolkitBackendJsAuthority *authority)
   duk_set_top (cx, 0);
   if (!duk_get_global_string (cx, "polkit")) {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error deleting old rules, not loading new ones");
       return;
   }
@@ -171,6 +176,7 @@ polkit_backend_common_reload_scripts (PolkitBackendJsAuthority *authority)
   duk_call_prop (cx, 0, 0);
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "Collecting garbage unconditionally...");
 
   load_scripts (authority);
@@ -596,6 +602,7 @@ runaway_killer_thread_execute_js (gpointer user_data)
 
   if ((pthread_err = pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldtype))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error setting thread cancel type: %s",
                                   strerror(pthread_err));
     goto err;
@@ -607,6 +614,7 @@ runaway_killer_thread_execute_js (gpointer user_data)
 
   if (!g_file_load_contents(file, NULL, &contents, &len, NULL, NULL)) {
     polkit_backend_authority_log(POLKIT_BACKEND_AUTHORITY(ctx->authority),
+                                 LOG_LEVEL_ERROR,
                                  "Error loading script %s", ctx->filename);
     g_object_unref(file);
     goto err;
@@ -619,6 +627,7 @@ runaway_killer_thread_execute_js (gpointer user_data)
   if (duk_peval_lstring(cx, contents, len) != 0)
   {
     polkit_backend_authority_log(POLKIT_BACKEND_AUTHORITY(ctx->authority),
+                                 LOG_LEVEL_ERROR,
                                  "Error compiling script %s: %s", ctx->filename,
                                  duk_safe_to_string(cx, -1));
     duk_pop(cx);
@@ -628,6 +637,7 @@ runaway_killer_thread_execute_js (gpointer user_data)
 
   if ((pthread_err = pthread_mutex_lock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error locking mutex: %s",
                                   strerror(pthread_err));
     return NULL;
@@ -641,6 +651,7 @@ free_err:
 err:
   if ((pthread_err = pthread_mutex_lock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error locking mutex: %s",
                                   strerror(pthread_err));
     return NULL;
@@ -649,12 +660,14 @@ err:
 end:
   if ((pthread_err = pthread_cond_signal(&ctx->cond))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error signaling on condition variable: %s",
                                   strerror(pthread_err));
     ctx->ret = RUNAWAY_KILLER_THREAD_EXIT_STATUS_FAILURE;
   }
   if ((pthread_err = pthread_mutex_unlock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error unlocking mutex: %s",
                                   strerror(pthread_err));
     ctx->ret = RUNAWAY_KILLER_THREAD_EXIT_STATUS_FAILURE;
@@ -671,6 +684,7 @@ runaway_killer_thread_call_js (gpointer user_data)
 
   if ((pthread_err = pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldtype))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error setting thread cancel type: %s",
                                   strerror(pthread_err));
     goto err;
@@ -679,6 +693,7 @@ runaway_killer_thread_call_js (gpointer user_data)
   if (duk_pcall_prop (cx, 0, 2) != DUK_EXEC_SUCCESS)
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error evaluating admin rules: %s",
                                     duk_safe_to_string (cx, -1));
       goto err;
@@ -686,6 +701,7 @@ runaway_killer_thread_call_js (gpointer user_data)
 
   if ((pthread_err = pthread_mutex_lock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error locking mutex: %s",
                                   strerror(pthread_err));
     return NULL;
@@ -697,6 +713,7 @@ runaway_killer_thread_call_js (gpointer user_data)
 err:
   if ((pthread_err = pthread_mutex_lock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error locking mutex: %s",
                                   strerror(pthread_err));
     return NULL;
@@ -705,12 +722,14 @@ err:
 end:
   if ((pthread_err = pthread_cond_signal(&ctx->cond))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error signaling on condition variable: %s",
                                   strerror(pthread_err));
     ctx->ret = RUNAWAY_KILLER_THREAD_EXIT_STATUS_FAILURE;
   }
   if ((pthread_err = pthread_mutex_unlock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (ctx->authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error unlocking mutex: %s",
                                   strerror(pthread_err));
     ctx->ret = RUNAWAY_KILLER_THREAD_EXIT_STATUS_FAILURE;
@@ -765,6 +784,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
 
   if ((pthread_err = pthread_mutex_lock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error locking mutex: %s",
                                   strerror(pthread_err));
     goto err_clean_cond;
@@ -772,6 +792,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
 
   if (clock_gettime(PK_CLOCK, &abs_time)) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error getting system's monotonic time: %s",
                                   strerror(errno));
     goto err_clean_cond;
@@ -781,6 +802,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
   if ((pthread_err = pthread_create(&authority->priv->runaway_killer_thread, NULL,
                                     js_context_cb, ctx))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error creating runaway JS killer thread: %s",
                                   strerror(pthread_err));
     goto err_clean_cond;
@@ -792,6 +814,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
 
       /* Log that we are terminating the script */
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_WARNING,
                                     "Terminating runaway script after %d seconds",
                                     RUNAWAY_KILLER_TIMEOUT);
 
@@ -800,6 +823,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
 
   if ((pthread_err = pthread_mutex_unlock(&ctx->mutex))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error unlocking mutex: %s",
                                   strerror(pthread_err));
     goto err_clean_cond;
@@ -808,6 +832,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
   if (cancel) {
     if ((pthread_err = pthread_cancel (authority->priv->runaway_killer_thread))) {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error cancelling runaway JS killer thread: %s",
                                     strerror(pthread_err));
       goto err_clean_cond;
@@ -815,6 +840,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
   }
   if ((pthread_err = pthread_join (authority->priv->runaway_killer_thread, NULL))) {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error joining runaway JS killer thread: %s",
                                     strerror(pthread_err));
       goto err_clean_cond;
@@ -884,6 +910,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
   duk_set_top (cx, 0);
   if (!duk_get_global_string (cx, "polkit")) {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error deleting old rules, not loading new ones");
       goto out;
   }
@@ -893,6 +920,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
   if (!push_action_and_details (cx, action_id, details, &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting action and details to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -902,6 +930,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
   if (!push_subject (cx, subject, user_for_subject, subject_is_local, subject_is_active, &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting subject to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -924,6 +953,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
       if (identity == NULL)
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_WARNING,
                                         "Identity `%s' is not valid, ignoring: %s",
                                         identity_str, error->message);
           g_clear_error (&error);
@@ -974,6 +1004,7 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
   if (!push_action_and_details (cx, action_id, details, &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting action and details to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -983,6 +1014,7 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
   if (!push_subject (cx, subject, user_for_subject, subject_is_local, subject_is_active, &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting subject to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -1005,6 +1037,7 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
   if (!polkit_implicit_authorization_from_string (ret_str, &ret))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_WARNING,
                                     "Returned result `%s' is not valid",
                                     ret_str);
       goto out;

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -592,6 +592,7 @@ log_result (PolkitBackendInteractiveAuthority    *authority,
     caller_cmdline = g_strdup ("<unknown>");
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "%s action %s for %s [%s] owned by %s (check requested by %s [%s])",
                                 log_result_str,
                                 action_id,
@@ -700,6 +701,7 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
       if (is_temp)
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_NOTIFY,
                                         "Operator of %s successfully authenticated as %s to gain "
                                         "TEMPORARY authorization for action %s for %s [%s] (owned by %s)",
                                         scope_str,
@@ -712,6 +714,7 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
       else
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_NOTIFY,
                                         "Operator of %s successfully authenticated as %s to gain "
                                         "ONE-SHOT authorization for action %s for %s [%s] (owned by %s)",
                                         scope_str,
@@ -725,6 +728,7 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
   else
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_NOTIFY,
                                     "Operator of %s FAILED to authenticate to gain "
                                     "authorization for action %s for %s [%s] (owned by %s)",
                                     scope_str,
@@ -1972,6 +1976,7 @@ append_property (GString *dest,
   else
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error substituting value for property $(%s) when preparing message `%s' for action-id %s",
                                     key,
                                     message,
@@ -2632,6 +2637,7 @@ polkit_backend_interactive_authority_register_authentication_agent (PolkitBacken
            locale);
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "Registered Authentication Agent for %s "
                                 "(system bus name %s [%s], object path %s, locale %s)",
                                 subject_as_string,
@@ -2789,6 +2795,7 @@ polkit_backend_interactive_authority_unregister_authentication_agent (PolkitBack
            agent->locale);
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "Unregistered Authentication Agent for %s "
                                 "(system bus name %s, object path %s, locale %s)",
                                 scope_str,
@@ -2941,6 +2948,7 @@ polkit_backend_interactive_authority_system_bus_name_owner_changed (PolkitBacken
                    agent->object_path);
 
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_NOTIFY,
                                         "Unregistered Authentication Agent for %s "
                                         "(system bus name %s, object path %s, locale %s) (disconnected from bus)",
                                         scope_str,

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -592,7 +592,7 @@ log_result (PolkitBackendInteractiveAuthority    *authority,
     caller_cmdline = g_strdup ("<unknown>");
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "%s action %s for %s [%s] owned by %s (check requested by %s [%s])",
                                 log_result_str,
                                 action_id,
@@ -701,7 +701,7 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
       if (is_temp)
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_NOTIFY,
+                                        LOG_LEVEL_NOTICE,
                                         "Operator of %s successfully authenticated as %s to gain "
                                         "TEMPORARY authorization for action %s for %s [%s] (owned by %s)",
                                         scope_str,
@@ -714,7 +714,7 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
       else
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_NOTIFY,
+                                        LOG_LEVEL_NOTICE,
                                         "Operator of %s successfully authenticated as %s to gain "
                                         "ONE-SHOT authorization for action %s for %s [%s] (owned by %s)",
                                         scope_str,
@@ -728,7 +728,7 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
   else
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                    LOG_LEVEL_NOTIFY,
+                                    LOG_LEVEL_NOTICE,
                                     "Operator of %s FAILED to authenticate to gain "
                                     "authorization for action %s for %s [%s] (owned by %s)",
                                     scope_str,
@@ -2637,7 +2637,7 @@ polkit_backend_interactive_authority_register_authentication_agent (PolkitBacken
            locale);
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "Registered Authentication Agent for %s "
                                 "(system bus name %s [%s], object path %s, locale %s)",
                                 subject_as_string,
@@ -2795,7 +2795,7 @@ polkit_backend_interactive_authority_unregister_authentication_agent (PolkitBack
            agent->locale);
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "Unregistered Authentication Agent for %s "
                                 "(system bus name %s, object path %s, locale %s)",
                                 scope_str,
@@ -2948,7 +2948,7 @@ polkit_backend_interactive_authority_system_bus_name_owner_changed (PolkitBacken
                    agent->object_path);
 
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_NOTIFY,
+                                        LOG_LEVEL_NOTICE,
                                         "Unregistered Authentication Agent for %s "
                                         "(system bus name %s, object path %s, locale %s) (disconnected from bus)",
                                         scope_str,

--- a/src/polkitbackend/polkitbackendjsauthority.cpp
+++ b/src/polkitbackend/polkitbackendjsauthority.cpp
@@ -194,7 +194,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       GDir *dir = NULL;
 
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                    LOG_LEVEL_NOTIFY,
+                                    LOG_LEVEL_NOTICE,
                                     "Loading rules from directory %s",
                                     dir_name);
 
@@ -259,7 +259,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
     }
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "Finished loading, compiling and executing %d rules",
                                 num_scripts);
   g_list_free_full (files, g_free);
@@ -287,7 +287,7 @@ polkit_backend_common_reload_scripts (PolkitBackendJsAuthority *authority)
     }
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "Collecting garbage unconditionally...");
   JS_GC (authority->priv->cx);
 

--- a/src/polkitbackend/polkitbackendjsauthority.cpp
+++ b/src/polkitbackend/polkitbackendjsauthority.cpp
@@ -163,6 +163,7 @@ static void report_error (JSContext     *cx,
 {
   PolkitBackendJsAuthority *authority = POLKIT_BACKEND_JS_AUTHORITY (JS_GetContextPrivate (cx));
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_ERROR,
                                 "%s:%u: %s",
                                 report->filename ? report->filename : "<no filename>",
                                 (unsigned int) report->lineno,
@@ -193,6 +194,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       GDir *dir = NULL;
 
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_NOTIFY,
                                     "Loading rules from directory %s",
                                     dir_name);
 
@@ -202,6 +204,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       if (dir == NULL)
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_ERROR,
                                         "Error opening rules directory: %s (%s, %d)",
                                         error->message, g_quark_to_string (error->domain), error->code);
           g_clear_error (&error);
@@ -231,6 +234,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
       if (!script)
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_ERROR,
                                         "Error compiling script %s",
                                         filename);
           continue;
@@ -243,6 +247,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
                                                &rval))
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_ERROR,
                                         "Error executing script %s",
                                         filename);
           continue;
@@ -254,6 +259,7 @@ load_scripts (PolkitBackendJsAuthority  *authority)
     }
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "Finished loading, compiling and executing %d rules",
                                 num_scripts);
   g_list_free_full (files, g_free);
@@ -275,11 +281,13 @@ polkit_backend_common_reload_scripts (PolkitBackendJsAuthority *authority)
                            &rval))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error deleting old rules, not loading new ones");
       return;
     }
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "Collecting garbage unconditionally...");
   JS_GC (authority->priv->cx);
 
@@ -838,7 +846,7 @@ js_operation_callback (JSContext *cx)
   g_mutex_unlock (&authority->priv->rkt_timeout_pending_mutex);
 
   /* Log that we are terminating the script */
-  polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority), "Terminating runaway script");
+  polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority), LOG_LEVEL_WARNING, "Terminating runaway script");
 
   /* Throw an exception - this way the JS code can ignore the runaway script handling */
   JS_ResetInterruptCallback (authority->priv->cx, TRUE);
@@ -995,6 +1003,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
   if (!action_and_details_to_jsval (authority, action_id, details, args[0], &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting action and details to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -1010,6 +1019,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
                          &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting subject to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -1022,6 +1032,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
                                              &rval))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error evaluating admin rules");
       goto out;
     }
@@ -1051,6 +1062,7 @@ polkit_backend_common_js_authority_get_admin_auth_identities (PolkitBackendInter
       if (identity == NULL)
         {
           polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                        LOG_LEVEL_WARNING,
                                         "Identity `%s' is not valid, ignoring (%s)",
                                         identity_str, error->message);
           g_clear_error (&error);
@@ -1098,6 +1110,7 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
   if (!action_and_details_to_jsval (authority, action_id, details, args[0], &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting action and details to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -1113,6 +1126,7 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
                          &error))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error converting subject to JS object: %s",
                                     error->message);
       g_clear_error (&error);
@@ -1125,6 +1139,7 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
                                              &rval))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_ERROR,
                                     "Error evaluating authorization rules");
       goto out;
     }
@@ -1154,6 +1169,7 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
   if (!polkit_implicit_authorization_from_string (ret_str.get(), &ret))
     {
       polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                    LOG_LEVEL_WARNING,
                                     "Returned result `%s' is not valid",
                                     ret_str.get());
       goto out;

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -74,6 +74,7 @@ on_name_lost (GDBusConnection *connection,
               gpointer         user_data)
 {
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_WARNING,
                                 "Lost the name org.freedesktop.PolicyKit1 - exiting");
   g_main_loop_quit (loop);
 }
@@ -86,6 +87,7 @@ on_name_acquired (GDBusConnection *connection,
   exit_status = EXIT_SUCCESS;
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                LOG_LEVEL_NOTIFY,
                                 "Acquired the name org.freedesktop.PolicyKit1 on the system bus");
 }
 

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -42,7 +42,7 @@ static gint                    opt_log_level = (gint) LOG_LEVEL_ERROR;
 static GOptionEntry            opt_entries[] = {
   {"replace", 'r', 0, G_OPTION_ARG_NONE, &opt_replace, "Replace existing daemon", NULL},
   {"no-debug", 'n', 0, G_OPTION_ARG_NONE, &opt_no_debug, "Don't print debug information to stderr and stdout", NULL},
-  {"log_level", 'l', 0, G_OPTION_ARG_INT, &opt_log_level, "Set a level of logging (default: errors only)",
+  {"log-level", 'l', 0, G_OPTION_ARG_INT, &opt_log_level, "Set a level of logging (default: errors only)",
           "Log level with the following values: 0 - errors only, 1 - include warnings, 2 - include regular notifications, 3 - verbose."},
   {NULL }
 };

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -38,9 +38,12 @@ static GMainLoop              *loop = NULL;
 static gint                    exit_status = EXIT_FAILURE;
 static gboolean                opt_replace = FALSE;
 static gboolean                opt_no_debug = FALSE;
+static gint                    opt_log_level = (gint) LOG_LEVEL_ERROR;
 static GOptionEntry            opt_entries[] = {
   {"replace", 'r', 0, G_OPTION_ARG_NONE, &opt_replace, "Replace existing daemon", NULL},
-  {"no-debug", 'n', 0, G_OPTION_ARG_NONE, &opt_no_debug, "Don't print debug information", NULL},
+  {"no-debug", 'n', 0, G_OPTION_ARG_NONE, &opt_no_debug, "Don't print debug information to stderr and stdout", NULL},
+  {"log_level", 'l', 0, G_OPTION_ARG_INT, &opt_log_level, "Set a level of logging (default: errors only)",
+          "Log level with the following values: 0 - errors only, 1 - include warnings, 2 - include regular notifications, 3 - verbose."},
   {NULL }
 };
 
@@ -225,6 +228,7 @@ main (int    argc,
     g_setenv ("PATH", "/usr/bin:/bin:/usr/sbin:/sbin", TRUE);
 
   authority = polkit_backend_authority_get ();
+  polkit_backend_authority_set_log_level( (guint) opt_log_level);
 
   loop = g_main_loop_new (NULL, FALSE);
 

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -42,8 +42,8 @@ static gint                    opt_log_level = (gint) LOG_LEVEL_ERROR;
 static GOptionEntry            opt_entries[] = {
   {"replace", 'r', 0, G_OPTION_ARG_NONE, &opt_replace, "Replace existing daemon", NULL},
   {"no-debug", 'n', 0, G_OPTION_ARG_NONE, &opt_no_debug, "Don't print debug information to stderr and stdout", NULL},
-  {"log-level", 'l', 0, G_OPTION_ARG_INT, &opt_log_level, "Set a level of logging (default: errors only)",
-          "Log level with the following values: 0 - errors only, 1 - include warnings, 2 - include regular notifications, 3 - verbose."},
+  {"log-level", 'l', 0, G_OPTION_ARG_INT, &opt_log_level, "Set a level of logging. Values (0-3): errors, warnings, notifications, verbose.",
+          "[0,1,2,3]"},
   {NULL }
 };
 
@@ -227,7 +227,7 @@ main (int    argc,
   if (g_getenv ("PATH") == NULL)
     g_setenv ("PATH", "/usr/bin:/bin:/usr/sbin:/sbin", TRUE);
 
-  polkit_backend_authority_set_log_level( (guint) opt_log_level);
+  polkit_backend_authority_set_log_level( opt_log_level);
 
   authority = polkit_backend_authority_get ();
 

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -42,8 +42,8 @@ static gint                    opt_log_level = (gint) LOG_LEVEL_ERROR;
 static GOptionEntry            opt_entries[] = {
   {"replace", 'r', 0, G_OPTION_ARG_NONE, &opt_replace, "Replace existing daemon", NULL},
   {"no-debug", 'n', 0, G_OPTION_ARG_NONE, &opt_no_debug, "Don't print debug information to stderr and stdout", NULL},
-  {"log-level", 'l', 0, G_OPTION_ARG_INT, &opt_log_level, "Set a level of logging. Values (0-3): errors, warnings, notifications, verbose.",
-          "[0,1,2,3]"},
+  {"log-level", 'l', 0, G_OPTION_ARG_INT, &opt_log_level, "Set a level of logging (syslog style). Levels (0-7): emergenencies, alerts, criticals, errors (default if not set), warnings, notices, infos, debug (verbose).",
+          "[0-7]"},
   {NULL }
 };
 
@@ -90,7 +90,7 @@ on_name_acquired (GDBusConnection *connection,
   exit_status = EXIT_SUCCESS;
 
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_NOTIFY,
+                                LOG_LEVEL_NOTICE,
                                 "Acquired the name org.freedesktop.PolicyKit1 on the system bus");
 }
 

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -227,8 +227,9 @@ main (int    argc,
   if (g_getenv ("PATH") == NULL)
     g_setenv ("PATH", "/usr/bin:/bin:/usr/sbin:/sbin", TRUE);
 
-  authority = polkit_backend_authority_get ();
   polkit_backend_authority_set_log_level( (guint) opt_log_level);
+
+  authority = polkit_backend_authority_get ();
 
   loop = g_main_loop_new (NULL, FALSE);
 


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
There was a request to being able to log every loaded .rules script. This required a change in the logging function and a new option parsed during the start of the polkit service.


## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
All the calls of the logging function had to be changed accordingly. The levels chosen for each such call were guessed from the message -> there might be discussions about that.  
The default log level is set to "notify" in the input unit file, this equals the original logging behaviour of polkit. The default and backup value in code is set to "errors only". The "default default" logging shall be "quiet", not too "verbose", but this is always subjective.  
A log message about every loaded rule file can be activated by editting the unit file and setting the log level to 3. 