### PR TITLE
test: skip if the namespace cannot be set up due to permissions or if python3 is too old

### DIFF
--- a/test/wrapper.py
+++ b/test/wrapper.py
@@ -32,6 +32,9 @@ def setup_test_namespace(data_dir):
     except PermissionError:
         print("Lacking permissions to set up test harness, skipping")
         sys.exit(77)
+    except AttributeError:
+        print("Python 3.12 is required for os.unshare(), skipping")
+        sys.exit(77)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
On some build systems, like Debian's, the tests do not have permissions to create new namespaces, so skip gracefully in that case

Follow-up for 8e17f09c770bc2efd5deb40ba2b6032d40603578
