### PR TITLE
Add meson option for privileged group

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,7 @@ option('systemdsystemunitdir', type: 'string', value: '', description: 'custom d
 option('libs-only', type: 'boolean', value: false, description: 'Only build libraries (skips building polkitd)')
 option('polkitd_user', type: 'string', value: 'polkitd', description: 'User for running polkitd (polkitd)')
 option('polkitd_uid', type: 'string', value: '-', description: 'Fixed UID for user running polkitd (polkitd)')
+option('privileged_group', type: 'string', value: 'wheel', description: 'Group to use for default privileged access')
 
 option('authfw', type: 'combo', choices: ['pam', 'shadow', 'bsdauth'], value: 'pam', description: 'Authentication framework (pam/shadow)')
 option('os_type', type: 'combo', choices: ['redhat', 'suse', 'gentoo', 'pardus', 'solaris', 'netbsd', 'lfs', ''], value: '', description: 'distribution or OS')

--- a/src/polkitbackend/50-default.rules.in
+++ b/src/polkitbackend/50-default.rules.in
@@ -8,5 +8,5 @@
 // about configuring polkit.
 
 polkit.addAdminRule(function(action, subject) {
-    return ["unix-group:wheel"];
+    return ["unix-group:@PRIVILEGED_GROUP@"];
 });

--- a/src/polkitbackend/meson.build
+++ b/src/polkitbackend/meson.build
@@ -59,8 +59,13 @@ libpolkit_backend = static_library(
   cpp_args: c_flags,
 )
 
-install_data(
-  '50-default.rules',
+configure_file(
+  input: '50-default.rules.in',
+  output: '@BASENAME@',
+  configuration: {
+    'PRIVILEGED_GROUP': get_option('privileged_group'),
+  },
+  install: true,
   install_dir: pk_pkgdatadir / 'rules.d',
 )
 


### PR DESCRIPTION
Add -Dprivileged_group that can be used to override the default of 'wheel', which is set in 50-default.rules. In Debian and derivatives, the privileged group is 'sudo', 'wheel' does not exist.

We have been carrying an out-of-tree patch in Debian to change the hard-coded group from wheel to sudo. This allows us to simply configure it via meson. Default is still the same.
