### PR TITLE
jsauthority: Bump mozjs to 128

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install build & test dependencies
         run: |
-          sudo dnf install -y dnf-plugins-core python3-dbusmock clang compiler-rt libasan libubsan mozjs115-devel
+          sudo dnf install -y dnf-plugins-core python3-dbusmock clang compiler-rt libasan libubsan mozjs128-devel
           sudo dnf builddep -y polkit
 
       - name: Build & test

--- a/meson.build
+++ b/meson.build
@@ -145,7 +145,7 @@ if js_engine == 'duktape'
   func = 'pthread_condattr_setclock'
   config_data.set('HAVE_' + func.to_upper(), cc.has_function(func, prefix : '#include <pthread.h>'))
 elif js_engine == 'mozjs'
-  js_dep = dependency('mozjs-115')
+  js_dep = dependency('mozjs-128')
 
   _system = host_machine.system().to_lower()
   if _system.contains('freebsd')

--- a/src/polkitbackend/polkitbackendjsauthority.cpp
+++ b/src/polkitbackend/polkitbackendjsauthority.cpp
@@ -165,7 +165,8 @@ static void report_error (JSContext     *cx,
   polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
                                 LOG_LEVEL_ERROR,
                                 "%s:%u: %s",
-                                report->filename ? report->filename : "<no filename>",
+                                report->filename ? report->filename.c_str()
+                                                 : "<no filename>",
                                 (unsigned int) report->lineno,
                                 report->message().c_str());
 }


### PR DESCRIPTION
## Summary

Firefox ESR 128 has been released and GNOME 47 has been updated to use it.  Do the same for Polkit.

`JSErrorReport::filename` is now a `ConstUTF8CharsZ`.  Invoke `c_str()` to get the C string.
