### PR TITLE
Fix missing arguments with HAVE_PTHREAD_CONDATTR_SETCLOCK

### DIFF
--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -767,12 +767,14 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
 #ifdef HAVE_PTHREAD_CONDATTR_SETCLOCK
   if ((pthread_err = pthread_condattr_init(&attr))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error initializing condition variable attributes: %s",
                                   strerror(pthread_err));
     return FALSE;
   }
   if ((pthread_err = pthread_condattr_setclock(&attr, PK_CLOCK))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error setting condition variable attributes: %s",
                                   strerror(pthread_err));
     goto err_clean_condattr;
@@ -780,6 +782,7 @@ runaway_killer_common(PolkitBackendJsAuthority *authority, RunawayKillerCtx *ctx
   /* Init again, with needed attr */
   if ((pthread_err = pthread_cond_init(&ctx->cond, &attr))) {
     polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
+                                  LOG_LEVEL_ERROR,
                                   "Error initializing condition variable: %s",
                                   strerror(pthread_err));
     goto err_clean_condattr;


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #

#482 added a new argument to `polkit_backend_authority_log` but it wasn't added to the calls inside of the `HAVE_PTHREAD_CONDATTR_SETCLOCK` ifdef.

## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #

Otherwise the polkit package on alpine linux edge fails to build: https://gitlab.alpinelinux.org/sertonix/aports/-/jobs/1479902

```
../src/polkitbackend/polkitbackendduktapeauthority.c:776:35: error: passing argument 2 of 'polkit_backend_authority_log' makes integer from pointer without a cast [-Wint-conversion]
  776 |                                   "Error setting condition variable attributes: %s",
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                   |
      |                                   char *
```
