### PR TITLE
Implement configuration reloading on SIGHUP and sd_notify support

### DIFF
--- a/data/polkit.service.in
+++ b/data/polkit.service.in
@@ -3,7 +3,7 @@ Description=Authorization Manager
 Documentation=man:polkit(8)
 
 [Service]
-Type=dbus
+Type=notify-reload
 BusName=org.freedesktop.PolicyKit1
 CapabilityBoundingSet=CAP_SETUID CAP_SETGID
 DeviceAllow=/dev/null rw

--- a/src/polkitbackend/polkitbackendactionpool.c
+++ b/src/polkitbackend/polkitbackendactionpool.c
@@ -446,6 +446,28 @@ polkit_backend_action_pool_get_all_actions (PolkitBackendActionPool *pool,
   return ret;
 }
 
+/**
+ * polkit_backend_action_pool_reload:
+ * @pool: A #PolkitBackendActionPool.
+ *
+ * Reload all PolicyKit actions in @pool.
+ **/
+void
+polkit_backend_action_pool_reload (PolkitBackendActionPool *pool)
+{
+  PolkitBackendActionPoolPrivate *priv;
+
+  if (!POLKIT_BACKEND_IS_ACTION_POOL (pool))
+    return;
+
+  priv = polkit_backend_action_pool_get_instance_private (pool);
+
+  g_hash_table_remove_all (priv->parsed_files);
+  g_hash_table_remove_all (priv->parsed_actions);
+  priv->has_loaded_all_files = FALSE;
+  ensure_all_files (pool);
+}
+
 /* ---------------------------------------------------------------------------------------------------- */
 
 static void

--- a/src/polkitbackend/polkitbackendactionpool.h
+++ b/src/polkitbackend/polkitbackendactionpool.h
@@ -71,6 +71,7 @@ GList                   *polkit_backend_action_pool_get_all_actions  (PolkitBack
 PolkitActionDescription *polkit_backend_action_pool_get_action       (PolkitBackendActionPool  *pool,
                                                                       const gchar              *action_id,
                                                                       const gchar              *locale);
+void                     polkit_backend_action_pool_reload           (PolkitBackendActionPool *pool);
 
 G_END_DECLS
 

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -34,6 +34,7 @@
 #include <polkit/polkit.h>
 #include "polkitbackendinteractiveauthority.h"
 #include "polkitbackendactionpool.h"
+#include "polkitbackendcommon.h"
 #include "polkitbackendsessionmonitor.h"
 
 #include <polkit/polkitprivate.h>
@@ -1402,6 +1403,28 @@ polkit_backend_interactive_authority_check_authorization_sync (PolkitBackendInte
     }
 
   return ret;
+}
+
+/**
+ * polkit_backend_interactive_authority_reload:
+ * @authority: A #PolkitBackendInteractiveAuthority.
+ *
+ * Reload configuration files.
+ */
+void
+polkit_backend_interactive_authority_reload (PolkitBackendInteractiveAuthority *authority)
+{
+  PolkitBackendInteractiveAuthorityPrivate *priv;
+  PolkitBackendJsAuthority *jsauthority;
+
+  if (!authority)
+    return;
+
+  priv = polkit_backend_interactive_authority_get_instance_private (authority);
+  polkit_backend_action_pool_reload (priv->action_pool);
+
+  jsauthority = POLKIT_BACKEND_JS_AUTHORITY (authority);
+  polkit_backend_common_reload_scripts (jsauthority);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/polkitbackend/polkitbackendinteractiveauthority.h
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.h
@@ -143,6 +143,7 @@ PolkitImplicitAuthorization polkit_backend_interactive_authority_check_authoriza
                                                           const gchar                       *action_id,
                                                           PolkitDetails                     *details,
                                                           PolkitImplicitAuthorization        implicit);
+void polkit_backend_interactive_authority_reload (PolkitBackendInteractiveAuthority *authority);
 
 G_END_DECLS
 

--- a/test/integration/systemd/test.sh
+++ b/test/integration/systemd/test.sh
@@ -12,7 +12,7 @@ at_exit() {
     : "Cleanup"
     userdel -rf "$TEST_USER"
     rm -f /etc/polkit-1/rules.d/99-test.rules
-    systemctl restart polkit
+    systemctl reload polkit
 }
 
 trap at_exit EXIT
@@ -34,7 +34,7 @@ EOF
 systemctl daemon-reload
 # Copy the test polkit rule in place
 cp -fv "$TEST_RULES/start-restart-stop-unit.rules" /etc/polkit-1/rules.d/99-test.rules
-systemctl restart polkit
+systemctl reload polkit
 # Following systemctl invocations should not trigger polkit's authentication prompt
 sudo -u "$TEST_USER" systemctl start start-restart-stop.service
 sudo -u "$TEST_USER" systemctl restart start-restart-stop.service


### PR DESCRIPTION
Add support for active reloading of config files via SIGHUP. Also integrate with sd_notify when building with libsystemd, and set Type=notify-reload in the systemd unit, so that a 'systemctl reload polkit' works out of the box.
This is especially useful when booting a read-only image, which gets configuration updates via overmounting with another read-only image.
