### PR TITLE
build: Don't install daemon files when building libs only

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -30,28 +30,30 @@ if enable_pam
   )
 endif
 
-configure_file(
-  input: 'polkit.service.in',
-  output: '@BASENAME@',
-  configuration: service_conf,
-  install: true,
-  install_dir: systemdsystemunitdir,
-)
+if not get_option('libs-only')
+  configure_file(
+    input: 'polkit.service.in',
+    output: '@BASENAME@',
+    configuration: service_conf,
+    install: true,
+    install_dir: systemdsystemunitdir,
+  )
 
-configure_file(
-  input: 'polkit.conf.in',
-  output: '@BASENAME@',
-  configuration: service_conf,
-  install: true,
-  install_dir: sysusers_dir,
-)
+  configure_file(
+    input: 'polkit.conf.in',
+    output: '@BASENAME@',
+    configuration: service_conf,
+    install: true,
+    install_dir: sysusers_dir,
+  )
 
-install_data(
-  'policyconfig-1.dtd',
-  install_dir: pk_datadir / 'polkit-1'
-)
+  install_data(
+    'policyconfig-1.dtd',
+    install_dir: pk_datadir / 'polkit-1'
+  )
 
-install_data(
-  'polkit-tmpfiles.conf',
-  install_dir: tmpfiles_dir
-)
+  install_data(
+    'polkit-tmpfiles.conf',
+    install_dir: tmpfiles_dir
+  )
+endif


### PR DESCRIPTION
Those files are only required when the daemon is in use, and because of their hard-coded paths when libsystemd isn't available, it fails to build in Flatpak.