### PR TITLE
meson: Support "openembedded" OS for PAM configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -298,7 +298,7 @@ endif
 
 pam_include = get_option('pam_include')
 if pam_include == ''
-  if ['suse', 'solaris'].contains(os_type)
+  if ['suse', 'solaris', 'openembedded'].contains(os_type)
     pam_conf = {
       'PAM_FILE_INCLUDE_AUTH': 'common-auth',
       'PAM_FILE_INCLUDE_ACCOUNT': 'common-account',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,7 @@ option('polkitd_uid', type: 'string', value: '-', description: 'Fixed UID for us
 option('privileged_group', type: 'string', value: 'wheel', description: 'Group to use for default privileged access')
 
 option('authfw', type: 'combo', choices: ['pam', 'shadow', 'bsdauth'], value: 'pam', description: 'Authentication framework (pam/shadow)')
-option('os_type', type: 'combo', choices: ['redhat', 'suse', 'gentoo', 'pardus', 'solaris', 'netbsd', 'lfs', ''], value: '', description: 'distribution or OS')
+option('os_type', type: 'combo', choices: ['redhat', 'suse', 'gentoo', 'pardus', 'solaris', 'netbsd', 'lfs', 'openembedded', ''], value: '', description: 'distribution or OS')
 
 option('pam_include', type: 'string', value: '', description: 'pam file to include')
 option('pam_module_dir', type: 'string', value: '', description: 'directory to install PAM security module')


### PR DESCRIPTION
## Summary
The Yocto/Openembedded project uses PAM integration with `common-*` files instead of the default `system-*`.
This PR adds  a `openembedded` `os_type` in meson (using the `suse` code path) to match that.

In Openembedded, same as Suse/Solaris: PAM files are common-*:
* PAM_FILE_INCLUDE_AUTH: common-auth
* PAM_FILE_INCLUDE_ACCOUNT: common-account
* PAM_FILE_INCLUDE_PASSWORD: common-password
* PAM_FILE_INCLUDE_SESSION: common-session

## Detailed description and/or reproducer
Since the automated OS detection will not work in a cross-compiler case. Polkit is built using the default `system-*` files and OE need to maintain a patch to change to `common-*`.