### PR TITLE
backendduktape: search for rules in /usr/local/share rather than /usr/local/lib and update docs

### DIFF
--- a/docs/man/polkit.xml
+++ b/docs/man/polkit.xml
@@ -107,10 +107,12 @@ System Context         |                        |
           |            | /usr/share/polkit-1/actions/*.policy |
           |            +--------------------------------------+
           |
-   +--------------------------------------+
-   | /etc/polkit-1/rules.d/*.rules        |
-   | /usr/share/polkit-1/rules.d/*.rules  |
-   +--------------------------------------+
+   +--------------------------------------------+
+   | /etc/polkit-1/rules.d/*.rules              |
+   | /run/polkit-1/rules.d/*.rules              |
+   | /usr/local/share/polkit-1/rules.d/*.rules  |
+   | /usr/share/polkit-1/rules.d/*.rules        |
+   +--------------------------------------------+
 ]]></programlisting>
       </textobject>
     </mediaobject>

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -256,7 +256,7 @@ polkit_backend_common_js_authority_constructed (GObject *object)
       authority->priv->rules_dirs = g_new0 (gchar *, 5);
       authority->priv->rules_dirs[0] = g_strdup (PACKAGE_SYSCONF_DIR "/polkit-1/rules.d");
       authority->priv->rules_dirs[1] = g_strdup ("/run/polkit-1/rules.d");
-      authority->priv->rules_dirs[2] = g_strdup ("/usr/local/lib/polkit-1/rules.d");
+      authority->priv->rules_dirs[2] = g_strdup ("/usr/local/share/polkit-1/rules.d");
       authority->priv->rules_dirs[3] = g_strdup (PACKAGE_DATA_DIR "/polkit-1/rules.d");
     }
 


### PR DESCRIPTION
The standard directory is /usr/share/polkit-1/rules.d, not /usr/lib/polkit-1/rules.d, so maintain consistency by searching in /usr/local/share/polkit-1/rules.d instead of /usr/local/lib/polkit-1/rules.d.

Follow-up for https://github.com/polkit-org/polkit/pull/498