### PR TITLE
Fix a couple of compilation warnings when building with clang

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -4,13 +4,6 @@ set -o pipefail
 
 # TODO
 #   - drop -Wno-deprecated-declarations
-#   - re-enable test-polkitbackendjsauthority
-#       - mocklibc overrides LD_PRELOAD, causing ASan to report false positives
-#         (with asan_verify_no_link=0)
-#   - re-enable unit tests built with ASan + sanitizers
-#       - currently polkit fails to build with clang >= 17 completely, and
-#         with older clang it needs to be built with -shared-libasan, which
-#         requires another set of tweaks to the environment
 
 PHASE="${1:?}"
 COMMON_BUILD_OPTS=(

--- a/meson.build
+++ b/meson.build
@@ -119,6 +119,14 @@ compiler_c_flags += cc.get_supported_arguments([
   '-Wno-declaration-after-statement',
 ])
 
+if cc.get_id() == 'gcc'
+  compiler_c_flags += cc.get_supported_arguments([
+    # -Wunused-result can't be suppressed by using (void) in gcc, so let's disable it for now
+    # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425
+    '-Wno-unused-result',
+  ])
+endif
+
 glib_req_version = '>= 2.30.0'
 
 gio_dep = dependency('gio-2.0', version: glib_req_version)

--- a/src/polkitbackend/polkitbackendactionpool.c
+++ b/src/polkitbackend/polkitbackendactionpool.c
@@ -260,44 +260,44 @@ polkit_backend_action_pool_set_property (GObject       *object,
   switch (prop_id)
     {
     case PROP_DIRECTORIES:
-
-      const gchar **dir_names = (const gchar**) g_value_get_boxed (value);
-
-      for (int n = 0; dir_names[n] != NULL; n++)
       {
-        GFile *file;
-        GFileMonitor *monitor;
-        GError *error = NULL;
+        const gchar **dir_names = (const gchar**) g_value_get_boxed (value);
 
-        const gchar *dir_name = dir_names[n];
+        for (int n = 0; dir_names[n] != NULL; n++)
+        {
+          GFile *file;
+          GFileMonitor *monitor;
+          GError *error = NULL;
 
-        file = g_file_new_for_path (dir_name);
-        priv->directories = g_list_prepend (priv->directories, file);
+          const gchar *dir_name = dir_names[n];
 
-        monitor = g_file_monitor_directory (file,
-                                            G_FILE_MONITOR_NONE,
-                                            NULL,
-                                            &error);
-        if (monitor == NULL)
-          {
-            g_warning ("Error monitoring actions directory: %s", error->message);
-            g_error_free (error);
-          }
-        else
-          {
-            g_signal_connect (monitor,
-                              "changed",
-                              (GCallback) dir_monitor_changed,
-                              pool);
-            priv->dir_monitors = g_list_prepend (priv->dir_monitors, monitor);
-          }
-      }
+          file = g_file_new_for_path (dir_name);
+          priv->directories = g_list_prepend (priv->directories, file);
 
-      priv->directories = g_list_reverse(priv->directories);
-      priv->dir_monitors = g_list_reverse(priv->dir_monitors);
+          monitor = g_file_monitor_directory (file,
+                                              G_FILE_MONITOR_NONE,
+                                              NULL,
+                                              &error);
+          if (monitor == NULL)
+            {
+              g_warning ("Error monitoring actions directory: %s", error->message);
+              g_error_free (error);
+            }
+          else
+            {
+              g_signal_connect (monitor,
+                                "changed",
+                                (GCallback) dir_monitor_changed,
+                                pool);
+              priv->dir_monitors = g_list_prepend (priv->dir_monitors, monitor);
+            }
+        }
 
-      break;
+        priv->directories = g_list_reverse(priv->directories);
+        priv->dir_monitors = g_list_reverse(priv->dir_monitors);
 
+        break;
+    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -1697,6 +1697,7 @@ _color_get (_Color color)
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+G_GNUC_PRINTF(3, 4)
 void
 polkit_backend_authority_log (PolkitBackendAuthority *authority,
                               const guint message_log_level,

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -173,8 +173,8 @@ become_user (const gchar  *user,
       goto out;
     }
 
-  setregid (pw->pw_gid, pw->pw_gid);
-  setreuid (pw->pw_uid, pw->pw_uid);
+  (void) setregid (pw->pw_gid, pw->pw_gid);
+  (void) setreuid (pw->pw_uid, pw->pw_uid);
   if ((geteuid () != pw->pw_uid) || (getuid () != pw->pw_uid) ||
       (getegid () != pw->pw_gid) || (getgid () != pw->pw_gid))
     {

--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -968,7 +968,7 @@ main (int argc, char *argv[])
   /* if not changing to uid 0, become uid 0 before changing to the user */
   if (pw->pw_uid != 0)
     {
-      setreuid (0, 0);
+      (void) setreuid (0, 0);
       if ((geteuid () != 0) || (getuid () != 0))
         {
           g_printerr ("Error becoming uid 0: %s\n", g_strerror (errno));
@@ -1021,8 +1021,8 @@ main (int argc, char *argv[])
       g_printerr ("Error initializing groups for %s: %s\n", pw->pw_name, g_strerror (errno));
       goto out;
     }
-  setregid (pw->pw_gid, pw->pw_gid);
-  setreuid (pw->pw_uid, pw->pw_uid);
+  (void) setregid (pw->pw_gid, pw->pw_gid);
+  (void) setreuid (pw->pw_uid, pw->pw_uid);
   if ((geteuid () != pw->pw_uid) || (getuid () != pw->pw_uid) ||
       (getegid () != pw->pw_gid) || (getgid () != pw->pw_gid))
     {

--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -86,6 +86,7 @@ usage (int argc, char *argv[])
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+G_GNUC_PRINTF(3, 4)
 static void
 log_message (gint     level,
              gboolean print_to_stderr,


### PR DESCRIPTION
There's still a bunch of warnings caused by `-Wdeprecated-declarations`, but these can be easily suppressed by `-Dc_args=-Wno-deprecated-declarations` for now.

This PR also tweaks the CI jobs to build with `-Werror`, so we should be able to catch these kind of issues a bit earlier in the future.