### PR TITLE
Shutdown polkitd properly on SIGTERM

### DIFF
--- a/src/polkit/polkitsystembusname.c
+++ b/src/polkit/polkitsystembusname.c
@@ -566,6 +566,7 @@ polkit_system_bus_name_get_creds_sync (PolkitSystemBusName           *system_bus
     }
 
   g_variant_unref (result);
+  g_variant_iter_free (iter);
 
   if (out_uid)
     *out_uid = uid;

--- a/src/polkitbackend/polkitbackendactionpool.c
+++ b/src/polkitbackend/polkitbackendactionpool.c
@@ -577,6 +577,7 @@ ensure_all_files (PolkitBackendActionPool *pool)
     if (error != NULL)
     {
       g_warning ("Error enumerating files in %s: %s", dir_name, error->message);
+      g_error_free (error);
     }
     else
     {

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -99,9 +99,9 @@ on_name_acquired (GDBusConnection *connection,
 }
 
 static gboolean
-on_sigint (gpointer user_data)
+on_sigint_sigterm (gpointer user_data)
 {
-  g_print ("Handling SIGINT\n");
+  g_print ("Handling %s\n", (const char *) user_data);
   g_main_loop_quit (loop);
   return TRUE;
 }
@@ -268,8 +268,12 @@ main (int    argc,
   loop = g_main_loop_new (NULL, FALSE);
 
   sigint_id = g_unix_signal_add (SIGINT,
-                                 on_sigint,
-                                 NULL);
+                                 on_sigint_sigterm,
+                                 "SIGINT");
+
+  sigint_id = g_unix_signal_add (SIGTERM,
+                                 on_sigint_sigterm,
+                                 "SIGTERM");
 
   sighup_id = g_unix_signal_add (SIGHUP,
                                  on_sighup,


### PR DESCRIPTION
While trying to break polkit using dfuzzer I couldn't make ASan/LSan
report _any_ memory leaks no matter how obvious they were. After a lot
of tinkering I managed to get the reports only when calling
`__lsan_do_recoverable_leak_check()` explicitly, which told me that the
shutdown `__lsan_do_leak_check() `is somehow getting skipped.

Turns out that polkitd does a "proper" shutdown on `SIGINT` (with which
ASan/LSan worked as expected), but not for `SIGTERM`. Fixing this, by
stopping the even loop even on SIGTERM, makes ASan/LSan happy (except
for the couple of memory leaks that were unfortunately hidden by this
behavior).

---

This PR together with #520 should be, for now, hopefully enough to let me introduce dfuzzer into polkit's test suite and address https://github.com/polkit-org/polkit/issues/515.

/cc @evverx