### PR TITLE
ci: do nightly polkit builds & submit them to Coverity

### DIFF
--- a/.github/workflows/coverity.sh
+++ b/.github/workflows/coverity.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+set -eux
+
+COVERITY_SCAN_TOOL_BASE="/tmp/coverity-scan-analysis"
+COVERITY_SCAN_PROJECT_NAME="polkit"
+
+coverity_install_script() {
+    local platform tool_url tool_archive
+
+    platform=$(uname)
+    tool_url="https://scan.coverity.com/download/${platform}"
+    tool_archive="/tmp/cov-analysis-${platform}.tgz"
+
+    set +x # this is supposed to hide COVERITY_SCAN_TOKEN
+    echo -e "\033[33;1mDownloading Coverity Scan Analysis Tool...\033[0m"
+    wget -nv -O "$tool_archive" "$tool_url" --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=${COVERITY_SCAN_TOKEN:?}"
+    set -x
+
+    mkdir -p "$COVERITY_SCAN_TOOL_BASE"
+    pushd "$COVERITY_SCAN_TOOL_BASE"
+    tar xzf "$tool_archive"
+    popd
+}
+
+run_coverity() {
+    local results_dir tool_dir results_archive sha response status_code
+
+    results_dir="cov-int"
+    tool_dir=$(find "$COVERITY_SCAN_TOOL_BASE" -type d -name 'cov-analysis*')
+    results_archive="analysis-results.tgz"
+    sha=$(git rev-parse --short HEAD)
+
+    meson setup build -Dtests=true -Dexamples=true
+    COVERITY_UNSUPPORTED=1 "$tool_dir/bin/cov-build" --dir "$results_dir" sh -c "ninja -C ./build -v"
+    "$tool_dir/bin/cov-import-scm" --dir "$results_dir" --scm git --log "$results_dir/scm_log.txt"
+
+    tar czf "$results_archive" "$results_dir"
+
+    set +x # this is supposed to hide COVERITY_SCAN_TOKEN
+    echo -e "\033[33;1mUploading Coverity Scan Analysis results...\033[0m"
+    response=$(curl \
+               --silent --write-out "\n%{http_code}\n" \
+               --form project="$COVERITY_SCAN_PROJECT_NAME" \
+               --form token="${COVERITY_SCAN_TOKEN:?}" \
+               --form email="${COVERITY_SCAN_NOTIFICATION_EMAIL:?}" \
+               --form file="@$results_archive" \
+               --form version="$sha" \
+               --form description="Daily build" \
+               https://scan.coverity.com/builds)
+    printf "\033[33;1mThe response is\033[0m\n%s\n" "$response"
+    status_code=$(echo "$response" | sed -n '$p')
+    if [ "$status_code" != "200" ]; then
+        echo -e "\033[33;1mCoverity Scan upload failed: $(echo "$response" | sed '$d').\033[0m"
+        return 1
+    fi
+    set -x
+}
+
+coverity_install_script
+run_coverity

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,36 @@
+---
+# vi: ts=2 sw=2 et:
+
+name: Coverity
+
+on:
+  schedule:
+    # Run Coverity daily at midnight
+    - cron:  '0 0 * * *'
+  pull_request:
+    paths:
+      - ".github/workflows/coverity.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'polkit-org/polkit'
+    env:
+      # Set in repo settings -> Secrets and variables -> Actions -> Repository secrets
+      COVERITY_SCAN_TOKEN:              "${{ secrets.COVERITY_SCAN_TOKEN }}"
+      COVERITY_SCAN_NOTIFICATION_EMAIL: "${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}"
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo sed -i 's/^Types: deb/Types: deb deb-src/g' /etc/apt/sources.list.d/*.sources
+          sudo apt update
+          sudo apt build-dep -y policykit-1
+
+      - name: Build & upload the results
+        run: .github/workflows/coverity.sh


### PR DESCRIPTION
_Note: I created this PR's branch intentionally directly in the upstream repo, so it has access to the repo secrets with the Coverity token, as PRs from forks can't do that._

Let's reintroduce regular Coverity builds. Since there's a pretty strict rate limit [0], do one nightly build each day, and upload it to Coverity for analysis. The results can be then found in the project dashboard [1].

[0] https://scan.coverity.com/faq#frequency
[1] https://scan.coverity.com/projects/polkit?tab=overview

Resolves: #517