### PR TITLE
test: run dfuzzer against Polkit's D-Bus interface

### DIFF
--- a/test/integration/dfuzzer/main.fmf
+++ b/test/integration/dfuzzer/main.fmf
@@ -1,0 +1,30 @@
+summary: Run dfuzzer against polkit's D-Bus interface
+test: ./test.sh
+require:
+    - clang
+    - compiler-rt
+    - coreutils
+    - dbus
+    - dbus-devel
+    - dfuzzer
+    - expat-devel
+    - gcc-c++
+    - gdb
+    - gettext-devel
+    - git
+    - glib2-devel
+    - glibc-devel
+    - gobject-introspection-devel
+    - gtk-doc
+    - libasan
+    - libubsan
+    - llvm
+    - meson
+    - pam-devel
+    - pkgconfig(duktape)
+    - python3-dbusmock
+    - systemd
+    - systemd-container
+    - systemd-devel
+    - util-linux
+duration: 30m

--- a/test/integration/dfuzzer/test.sh
+++ b/test/integration/dfuzzer/test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# vi: set sw=4 ts=4 et tw=110:
+# shellcheck disable=SC2016
+#
+# FIXME: this test can be _drastically_ simplified once we can run a dedicated sanitizer job, see
+#        https://github.com/packit/packit-service/issues/2610
+
+set -eux
+set -o pipefail
+
+# shellcheck source=test/integration/util.sh
+. "$(dirname "$0")/../util.sh"
+
+export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_invalid_pointer_pairs=2:handle_ioctl=1:print_cmdline=1:disable_coredump=0:use_madv_dontdump=1
+export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
+# FIXME: There' a bug in meson where it overrides UBSAN_OPTIONS when MSAN_OPTIONS is not set, see
+#        https://github.com/mesonbuild/meson/pull/13001. Drop this once v1.4.1 is widespread enough
+export MSAN_OPTIONS=foo
+export CC="${CC:-clang}"
+
+# shellcheck disable=SC2317
+at_exit() {
+    set +ex
+
+    # Let's do some cleanup and export logs if necessary
+
+    # Collect potential coredumps
+    coredumpctl_collect
+    container_destroy
+
+    if [[ -n "${TMT_TEST_DATA:-}" && -n "${BUILD_DIR:-}" ]]; then
+        cp -r "$BUILD_DIR/meson-logs" "$TMT_TEST_DATA/"
+    fi
+}
+
+trap at_exit EXIT
+
+export BUILD_DIR="$PWD/build-san"
+
+# Make sure the coredump collecting machinery is working
+coredumpctl_init
+
+: "=== Prepare polkit's source tree ==="
+# The integration test suite runs without access to the source tree it was built from. If we need the source
+# tree (most likely to rebuild polkit) we need to do a little dance to determine the correct references.
+if [[ -n "${PACKIT_TARGET_URL:-}" ]]; then
+    # If we're running in Packit's context, use the set of provided environment variables to checkout the
+    # correct branch (and possibly rebase it on top of the latest source base branch so we always test the
+    # latest revision possible).
+    git clone "$PACKIT_TARGET_URL" polkit
+    cd polkit
+    git checkout "$PACKIT_TARGET_BRANCH"
+    # If we're invoked from a pull request context, rebase on top of the latest source base branch.
+    if [[ -n "${PACKIT_SOURCE_URL:-}" ]]; then
+        git remote add pr "${PACKIT_SOURCE_URL:?}"
+        git fetch pr "${PACKIT_SOURCE_BRANCH:?}"
+        git merge "pr/$PACKIT_SOURCE_BRANCH"
+    fi
+    git log --oneline -5
+elif [[ -n "${POLKIT_TREE:-}" ]]; then
+    # Useful for quick local debugging when running this script directly, e.g. running
+    #
+    #   # TMT_TEST_DATA=$PWD/logs POLKIT_TREE=$PWD test/integration/fuzz/sanitizers/test.sh
+    #
+    # from the polkit repo root.
+    cd "${POLKIT_TREE:?}"
+else
+    # If we're running outside of Packit's context, pull the latest polkit upstream.
+    git clone https://github.com/polkit-org/polkit polkit
+    cd polkit
+    git log --oneline -5
+fi
+
+: "=== Build polkit with sanitizers ==="
+MESON_OPTIONS=()
+
+if [[ "$CC" == clang ]]; then
+    # See https://github.com/mesonbuild/meson/issues/764 for details
+    MESON_OPTIONS+=(-Db_lundef=false)
+fi
+
+rm -rf "$BUILD_DIR"
+# FIXME:
+#   - drop -Wno-deprecated-declarations once it's not needed
+#   - generating introspection is currently FUBAR when building with clang + ASan,
+#     but we shouldn't need it here anyway (see https://github.com/mesonbuild/meson/issues/13211)
+meson setup "$BUILD_DIR" \
+    --werror \
+    -Dintrospection=false \
+    -Dsession_tracking=logind \
+    -Dgettext=true \
+    -Dtests=true \
+    -Db_sanitize=address,undefined \
+    -Dc_args="-Wno-deprecated-declarations" \
+    -Dcpp_args="-Wno-deprecated-declarations" \
+    "${MESON_OPTIONS[@]}"
+ninja -C "$BUILD_DIR"
+meson test -C "$BUILD_DIR" --print-errorlogs
+
+: "=== Run dfuzzer against polkit running under sanitizers ==="
+container_prepare
+
+# Install our custom-built polkit into the container's overlay
+DESTDIR="$CONTAINER_OVERLAY" ninja -C "$BUILD_DIR" install
+# Tweak the polkit.service to make it compatible with sanitizers
+mkdir -p "$CONTAINER_OVERLAY/etc/systemd/system/polkit.service.d/"
+cat >"$CONTAINER_OVERLAY/etc/systemd/system/polkit.service.d/sanitizer-env.conf" <<EOF
+[Service]
+# Pass ASAN_OPTIONS and UBSAN_OPTIONS to the polkit service in the container
+Environment=ASAN_OPTIONS=$ASAN_OPTIONS
+Environment=UBSAN_OPTIONS=$UBSAN_OPTIONS
+# Get rid of any existing seccomp filters to allow sanitizers do their work
+SystemCallFilter=
+# Get rid of --no-debug (since sanitizers log their findings to stderr), and let polkit be as verbose as
+# possible
+ExecStart=
+ExecStart=/usr/lib/polkit-1/polkitd --log-level=debug
+EOF
+
+check_journal_for_sanitizer_errors() {
+    if journalctl -q -D "/var/log/journal/${CONTAINER_MACHINE_ID:?}" --grep "SUMMARY:.+Sanitizer"; then
+        # Dump all messages recorded for the polkit.service, as that's usually where the stack trace ends
+        # up. If that's not the case, the full container journal is exported on test exit anyway, so we'll
+        # still have everything we need to debug the fail further.
+        journalctl -q -D "/var/log/journal/${CONTAINER_MACHINE_ID:?}" -o short-monotonic --no-hostname -u polkit.service --no-pager
+        exit 1
+    fi
+}
+
+run_and_check() {
+    local run=(container_run)
+    local ec=0
+
+    if [[ "$1" == "--unpriv" ]]; then
+        run=(container_run_user testuser)
+        shift
+    fi
+
+    # Run the passed command in the container
+    "${run[@]}" "$@" || ec=$?
+    # Check for potential stack traces from sanitizers
+    check_journal_for_sanitizer_errors
+    # Check if polkit is still running
+    "${run[@]}" systemctl status --full --no-pager polkit.service
+
+    return $ec
+}
+
+# Start the container and wait until it's fully booted up
+container_start
+container_run pkexec --version
+container_run systemctl start polkit.service
+container_run systemctl --no-pager status polkit.service
+# Make _extra_ sure we're running the sanitized polkit with the correct environment
+#
+# Note: the check is not particularly nice, as libasan can be linked either statically or dynamically, so we
+# can't just check ldd's output. Another option is using nm/objdump to check for ASan-specific functions, but
+# that's also error prone. Instead, let's call each binary with ASan's "help" option, which produces output
+# only if the target binary is built with (hopefully working) ASan.
+container_run bash -xec 'ASAN_OPTIONS=help=1 /proc/$(systemctl show -P MainPID polkit.service)/exe -h 2>&1 >/dev/null | grep -q AddressSanitizer'
+container_run systemctl show -p Environment polkit.service | grep -q ASAN_OPTIONS
+
+# Now we should have a container ready for our shenanigans
+
+# Fuzz polkit's own interface
+run_and_check dfuzzer -v -n org.freedesktop.PolicyKit1
+run_and_check --unpriv dfuzzer -v -n org.freedesktop.PolicyKit1
+
+# Shut down the container and check for any sanitizer errors, since some of the errors can be detected only
+# after we start shutting things down.
+container_stop
+check_journal_for_sanitizer_errors
+# Also, check if polit didn't fail during the lifetime of the container
+(! journalctl -q -D "/var/log/journal/$CONTAINER_MACHINE_ID" _PID=1 --grep "polkit.service.*Failed with result")
+
+exit 0

--- a/test/integration/util.sh
+++ b/test/integration/util.sh
@@ -1,0 +1,215 @@
+# vi: set sw=4 ts=4 et tw=110:
+# shellcheck shell=bash disable=SC2155
+
+CONTAINER_NAME=""
+CONTAINER_MACHINE_ID=""
+CONTAINER_OVERLAY=""
+
+__COREDUMPCTL_TS=""
+
+# Prepare a systemd-nspawn container so we can test a custom polkit version without affecting the test
+# machine.
+#
+# This function prepares a lightweight nspawn container that reuses the rootfs of the underlying test machine
+# to run polkit under various tools (or a completely custom-built polkit version) without risking
+# damage to the underlying test machine. The container simply combines the /etc and /usr directories from the
+# host with our own additions using overlayfs, which is then bind-mounted into the container, so we do a full
+# user-space boot without needing to build a custom image or restart the underlying test machine itself.
+#
+# The function exports/modifies three environment variables:
+#   - $CONTAINER_NAME - container name that can be used to identify the machine in machinectl calls (or in
+#                       direct calls to the systemd-nspawn@.service template)
+#   - $CONTAINER_MACHINE_ID - machine ID of the container, which can be used to locate the container's journal
+#                             under /var/log/journal/$CONTAINER_MACHINE_ID
+#   - $CONTAINER_OVERLAY - upper layer of the container overlayfs that can be used to add additional bits into
+#                          the final container (note that only /etc and /usr subdirectores from this direcory
+#                          are used)
+#
+# Once the container is ready, it can be booted up using container_start(). To execute commands inside the
+# container, container_run() and container_run_user() might come in handy.
+container_prepare() {
+    # Export a couple of env variables which can be used to track/alter the container
+    CONTAINER_NAME="polkit-container-$RANDOM"
+    CONTAINER_MACHINE_ID="$(systemd-id128 new)"
+    CONTAINER_OVERLAY="/var/lib/machines/$CONTAINER_NAME"
+
+    # Switch SELinux to permissive (if enabled), so it doesn't interfere with the container shenanigans below.
+    setenforce 0 || :
+    # We need persistent journal for the systemd-nspawn --link= stuff
+    mkdir -p /var/log/journal
+    journalctl --flush
+
+    # Prepare the nspawn container service
+    mkdir -p "/var/lib/machines/$CONTAINER_NAME"
+    # Notes:
+    #   - with systemd v256+ this can be replaced by systemctl edit --stdin --runtime ..., and the
+    #     mkdir/daemon-reload can be dropped
+    #   - systemd-nspawn can't overlay the whole rootfs (/), so we need to cherry-pick a couple of subdirectories
+    #     we're interested in (in this case it's pretty simple, since polkit installs everything under /usr,
+    #     and we need /etc with our polkit.service override)
+    #   - since the whole container is ephemeral, use --link-journal=host, so the journal directory for the
+    #     container is created on the _host_ under /var/log/journal/<machine-id> and bind-mounted into the
+    #     container; that way we can fetch the container journal for debugging even if something goes horribly
+    #     wrong
+    mkdir -p "/run/systemd/system/systemd-nspawn@$CONTAINER_NAME.service.d"
+    cat >"/run/systemd/system/systemd-nspawn@$CONTAINER_NAME.service.d/override.conf" <<EOF
+    [Service]
+# We'll handle the coredumps on the host instead
+CoredumpReceive=no
+ExecStart=
+ExecStart=systemd-nspawn --quiet --network-veth --keep-unit --machine=%i --boot \
+                         --link-journal=host \
+                         --volatile=yes \
+                         --directory=/ \
+                         --uuid=$CONTAINER_MACHINE_ID \
+                         --hostname=$CONTAINER_NAME \
+                         --overlay=/etc:$CONTAINER_OVERLAY/etc:/etc \
+                         --overlay-ro=/usr:$CONTAINER_OVERLAY/usr:/usr \
+                         ${BUILD_DIR:+"--bind=$BUILD_DIR:$BUILD_DIR"}
+EOF
+    systemctl daemon-reload
+
+
+    # Prepare the nspawn container overlay
+    mkdir "$CONTAINER_OVERLAY"/{etc,usr}/
+    # Let systemd-nspawn propagate the machine ID and hostname we passed it
+    : >"$CONTAINER_OVERLAY/etc/machine-id"
+    : >"$CONTAINER_OVERLAY/etc/hostname"
+    # Create a non-root user, so we can test session bus stuff as well
+    mkdir -p "$CONTAINER_OVERLAY/etc/sysusers.d/"
+    cat >"$CONTAINER_OVERLAY/etc/sysusers.d/testuser.conf" <<EOF
+u testuser - "Test User" /home/testuser
+EOF
+}
+
+# Start the container created by container_prepare() and wait until it boots.
+container_start() {
+    if [[ -z "$CONTAINER_NAME" ]]; then
+        echo >&2 "No container to start (missing call to container_prepare()?)"
+        return 1
+    fi
+
+    machinectl start "$CONTAINER_NAME"
+    timeout --foreground 30s bash -ec "until systemd-run -M $CONTAINER_NAME --wait --pipe true; do sleep .5; done"
+    # is-system-running returns > 0 if the system is running in degraded mode, but we don't care about that, we
+    # just need to wait until the bootup is finished
+    container_run systemctl is-system-running -q --wait || :
+}
+
+container_stop() {
+    # Note: machinectl poweroff doesn't wait until the container shuts down completely, stop stop the service
+    #       behind it instead which does wait
+    systemctl stop "systemd-nspawn@${CONTAINER_NAME:?}.service"
+}
+
+# Run a command in a container as a root.
+container_run() {
+    systemd-run -M "${CONTAINER_NAME:?}" --wait --pipe "$@"
+}
+
+# Same as above, but run the command under a specific user.
+container_run_user() {
+    local user="${1:?}"
+    shift
+
+    systemd-run -M "$user@${CONTAINER_NAME:?}" --user --wait --pipe "$@"
+}
+
+container_destroy() {
+    if [[ -z "$CONTAINER_NAME" ]]; then
+        return 0
+    fi
+
+    if systemctl -q is-active "systemd-nspawn@$CONTAINER_NAME.service"; then
+        container_stop
+    fi
+
+    # Export the container journal and sanitizer logs if $TMT_TEST_DATA is set, either by TMT directly or
+    # manually.
+    if [[ -n "${TMT_TEST_DATA:-}" ]]; then
+        mkdir -p "$TMT_TEST_DATA"
+        journalctl -D "/var/log/journal/$CONTAINER_MACHINE_ID" -o short-monotonic >"$TMT_TEST_DATA/$CONTAINER_NAME.log"
+    fi
+
+    rm -rf "/var/lib/machines/$CONTAINER_NAME"
+    rm -rf "/var/log/journal/$CONTAINER_MACHINE_ID"
+    rm -rf "/run/systemd/system/systemd-nspawn@$CONTAINER_NAME.service.d"
+    systemctl daemon-reload
+}
+
+coredumpctl_init() {
+    local ec
+
+    if ! systemctl start systemd-coredump.socket; then
+        echo >&2 "Failed to start systemd-coredump.socket"
+        return 1
+    fi
+
+    # Note: coredumpctl returns 1 when no coredumps are found
+    coredumpctl --since=now >/dev/null && ec=0 || ec=$?
+    if [[ $ec -ne 1 ]]; then
+        echo >&2 "coredumpctl is not in operative state"
+        return 1
+    fi
+
+    # Set the internal coredumpctl timestamp, so we consider coredumps only from now on
+    __COREDUMPCTL_TS="$(date +"%Y-%m-%d %H:%M:%S")"
+
+    return 0
+}
+
+# Attempt to dump info about relevant coredumps using the coredumpctl utility.
+#
+# Returns:
+#   0 when no coredumps were found, 1 otherwise
+coredumpctl_collect() (
+    set +ex
+
+    local args=(-q --no-legend --no-pager)
+    local tempfile="$(mktemp)"
+
+    # Register a cleanup handler
+    #
+    # Note: since this function is a technically a subshell, RETURN trap won't work here
+    # shellcheck disable=SC2064
+    trap "rm -f '$tempfile'" EXIT
+
+    if [[ -n "$__COREDUMPCTL_TS" ]]; then
+        args+=(--since "$__COREDUMPCTL_TS")
+    fi
+
+    if ! coredumpctl "${args[@]}" -F COREDUMP_EXE >"$tempfile"; then
+        echo "No relevant coredumps found"
+        return 0
+    fi
+
+    # For each unique executable path call 'coredumpctl info' to get the stack trace and other useful info
+    while read -r path; do
+        local exe
+        local gdb_cmd="set print pretty on\nbt full"
+
+        coredumpctl "${args[@]}" info "$path"
+        # Make sure we use the built binaries for getting gdb trace
+        #
+        # This is relevant mainly for the sanitizers run, where we don't install the just built revision, so
+        # `coredumpctl debug` pulls in a local binary instead of the built one, which produces useless
+        # results.
+        if [[ -v BUILD_DIR && -d $BUILD_DIR ]]; then
+            # The build directory layout of polkit is not flat, so we need to find the binary first
+            exe="$(find "$BUILD_DIR" -executable -name "${path##*/}" | head -n1)"
+            if [[ -n "$exe" ]]; then
+                gdb_cmd="file $exe\nthread apply all bt\n$gdb_cmd"
+            fi
+        fi
+
+        # Attempt to get a full stack trace for the first occurrence of the given executable path
+        if gdb -v >/dev/null; then
+            echo -e "\n"
+            echo "Trying to run gdb with '$gdb_cmd' for '$path'"
+            echo -e "$gdb_cmd" | coredumpctl "${args[@]}" debug "$path"
+            echo -e "\n"
+        fi
+    done < <(sort -u "$tempfile")
+
+    return 1
+)


### PR DESCRIPTION
Let's run dfuzzer to fuzz polkit's own D-Bus interface to catch issues
like [0][1][2] early.

The test implementation is a _bit_ convoluted, caused by the fact that
we have to rebuild polkit with Address and Undefined sanitizers to make
dfuzzer considerably more effective. This also involves running the just
built polkit in a lightweight container so we don't mess with the
already installed polkit (which could affect tests running after this
one that don't expect sanitized polkit). All this extra code can be
potentially dropped once we're able to do multiple Packit builds in one
PR (currently in an RFC stage).

Resolves: https://github.com/polkit-org/polkit/issues/515

[0] https://github.com/polkit-org/polkit/issues/506
[1] https://github.com/polkit-org/polkit/commit/b709b693346712bf8e8d8e8c77f71b7918fa367d
[2] https://github.com/polkit-org/polkit/commit/5cce296a8d60a3395c1a372377bdf8f01ed93872