### PR TITLE
ci: run Packit on commit events as well

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,12 @@ downstream_package_name: polkit
 
 jobs:
 - job: copr_build
+  trigger: commit
+  preserve_project: true
+  targets:
+  - fedora-rawhide-x86_64
+
+- job: copr_build
   trigger: pull_request
   targets:
   - fedora-all-aarch64


### PR DESCRIPTION
Let's do a Packit build on "commit" events as well, which automagically enables Packit's OpenScanHub integration [0].

Since OSH runs only on x86_64 Fedora Rawhide builds, let's limit the scope for the "commit" event adequately; we still do the usual builds across all supported Fedora releases (and architectures) in PRs.

The OSH integration is still in its experimental stage, but there's a plan to add SARIF support and integrate it into GitHub's UI (see [1]), which should make it quite useful.

[0] https://packit.dev/posts/openscanhub-prototype
[1] https://github.com/packit/dashboard/issues/441

---

Note: this won't have any effect until it's merged, as OSH needs at least one build from the default (main) branch to have something to compare against.