### PR TITLE
fix: need goto out after g_set_error

### DIFF
--- a/src/polkitbackend/polkitbackendsessionmonitor-systemd.c
+++ b/src/polkitbackend/polkitbackendsessionmonitor-systemd.c
@@ -374,6 +374,7 @@ polkit_backend_session_monitor_get_session_for_subject (PolkitBackendSessionMoni
                    POLKIT_ERROR_NOT_SUPPORTED,
                    "Cannot get session for subject of type %s",
                    g_type_name (G_TYPE_FROM_INSTANCE (subject)));
+      goto out;
     }
 
 #if HAVE_SD_PIDFD_GET_SESSION


### PR DESCRIPTION
fix: need goto out after g_set_error

goto out needs to be executed after g_set_error , otherwise the assertion will be triggered in g_assert (process != NULL);
