### PR TITLE
auth_keep: do not ask for reauth if new process shares same UID/parent/cgroup/tty

### DIFF
--- a/src/polkit/polkitunixprocess.h
+++ b/src/polkit/polkitunixprocess.h
@@ -60,6 +60,7 @@ PolkitSubject  *polkit_unix_process_new_pidfd      (gint               pidfd,
                                                     GArray            *gids);
 GArray         *polkit_unix_process_get_gids       (PolkitUnixProcess *process);
 gint            polkit_unix_process_get_pid        (PolkitUnixProcess *process);
+gint            polkit_unix_process_get_ppid       (PolkitUnixProcess *process);
 guint64         polkit_unix_process_get_start_time (PolkitUnixProcess *process);
 gint            polkit_unix_process_get_uid        (PolkitUnixProcess *process);
 void            polkit_unix_process_set_gids       (PolkitUnixProcess *process,
@@ -73,6 +74,9 @@ void            polkit_unix_process_set_start_time (PolkitUnixProcess *process,
 
 gint            polkit_unix_process_get_owner      (PolkitUnixProcess  *process,
                                                     GError            **error) G_GNUC_DEPRECATED_FOR (polkit_unix_process_get_uid);
+gint            polkit_unix_process_get_ppidfd     (PolkitUnixProcess  *process);
+guint           polkit_unix_process_get_ctty       (PolkitUnixProcess  *process);
+guint64         polkit_unix_process_get_cgroupid   (PolkitUnixProcess  *process);
 gint            polkit_unix_process_get_pidfd      (PolkitUnixProcess  *process);
 void            polkit_unix_process_set_pidfd      (PolkitUnixProcess  *process,
                                                     gint                pidfd);


### PR DESCRIPTION
sudo keeps a record of authenticated processes via either the controlling TTY (default) or the parent process id.

Implement the same caching behaviour, but stricter: if a process is authenticated for auth_keep, do not expunge it when it exits if it was tracked via PID FD (to make it safe against reuse attacks).

Then, if another process comes along, skip re-auth and allow it if it shared the same UID, parent process id, cgroup id and controlling terminal (and all processes are newer than the controlling terminal ctime). PID FDs must be used all the way through, otherwise there's no caching.

This is much stricter than sudo, as all conditions must be met. But it still allows to fulfill the main use case, which is to run multiple commands on the same terminal without being asked for the password again and again.

Unlike sudo, we also do not refresh the countdown on each use.

Fixes #472

This allows running `run0` or `systemctl` and friends multiple times from the same terminal without having to re-enter the password multiple times, if within the default temporary auth_keep time window (5 minutes)
