### PR TITLE
Explicitly use chdir("/") instead of relying on ~user being set properly

### DIFF
--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -184,10 +184,10 @@ become_user (const gchar  *user,
       goto out;
     }
 
-  if (chdir (pw->pw_dir) != 0)
+  if (chdir ("/") != 0)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Error changing to home directory %s: %m",
+                   "Error changing to root directory %s: %m",
                    pw->pw_dir);
       goto out;
     }


### PR DESCRIPTION
On non-systemd systems if the user is changed manually, polkitd will also change directory. The homedir of the user might not be set correctly, so just change to /.

This is a no-op on systemd systems, as the user is set in the unit file, so this code never runs.
