### PR TITLE
CI: Drop mozjs-devel from test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install build & test dependencies
         run: |
-          dnf install -y dnf-plugins-core python3-dbusmock clang compiler-rt libasan libubsan mozjs115-devel
+          dnf install -y dnf-plugins-core python3-dbusmock clang compiler-rt libasan libubsan
           dnf builddep -y polkit
 
       - name: Build & test


### PR DESCRIPTION
Fix-up (https://github.com/polkit-org/polkit/commit/e0c6725e378d01865e5967db5d7ca596e237d34f).