### PR TITLE
meson: fix unused dependency, fixes elogind FTBFS

### DIFF
--- a/src/polkitbackend/meson.build
+++ b/src/polkitbackend/meson.build
@@ -37,7 +37,6 @@ deps += thread_dep
 
 if enable_logind
   sources += files('polkitbackendsessionmonitor-systemd.c')
-
   deps += logind_dep
 else
   sources += files('polkitbackendsessionmonitor.c')
@@ -73,7 +72,7 @@ executable(
   program,
   program + '.c',
   include_directories: top_inc,
-  dependencies: libpolkit_gobject_dep,
+  dependencies: deps,
   c_args: c_flags,
   link_with: libpolkit_backend,
   install: true,


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
polkit-126 could not be built from source with elogind session service due to wrong dependencies in meson.build.

Author: @markhindley


## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
