### PR TITLE
A couple of fixes for recent CI fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Install build & test dependencies
         run: |
-          sudo dnf install -y dnf-plugins-core python3-dbusmock clang compiler-rt libasan libubsan mozjs115-devel
-          sudo dnf builddep -y polkit
+          dnf install -y dnf-plugins-core python3-dbusmock clang compiler-rt libasan libubsan mozjs115-devel
+          dnf builddep -y polkit
 
       - name: Build & test
-        run: sudo --preserve-env=GITHUB_ACTIONS,CI .github/workflows/ci.sh ${{ matrix.phase }}
+        run: .github/workflows/ci.sh ${{ matrix.phase }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,8 @@ jobs:
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3
+      env:
+        CODEQL_EXTRACTOR_CPP_AUTOINSTALL_DEPENDENCIES: false
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,12 +28,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        queries: +security-extended,security-and-quality
-
     - name: Install dependencies
       if: ${{ matrix.language == 'c-cpp' }}
       run: |
@@ -42,6 +36,12 @@ jobs:
         sudo apt build-dep -y policykit-1
         # polkit in Ubuntu Jammy (ATTOW) doesn't have the latest build dependencies yet
         sudo apt install -y duktape-dev meson
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        queries: +security-extended,security-and-quality
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
This PR should make the _Build & Test_ and _CodeQL_  CI jobs green again by:
  - not using `sudo` in the Fedora test container, since we already have root anyway
  - disabling automatic dependency installation during CodeQL's autobuild, since it started pulling in `sccache` which breaks code tracing during the (auto)build