### PR TITLE
ci: build & run unit tests on Alpine as well

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -6,12 +6,13 @@ set -o pipefail
 #   - drop -Wno-deprecated-declarations
 
 PHASE="${1:?}"
+SESSION_TRACKING="${2:?}"
 COMMON_BUILD_OPTS=(
     -Dauthfw=pam
     -Dexamples=true
     -Dgtk_doc=true
     -Dintrospection=true
-    -Dsession_tracking=logind
+    -Dsession_tracking="$SESSION_TRACKING"
     -Dtests=true
 )
 

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -15,7 +15,7 @@ COMMON_BUILD_OPTS=(
     -Dtests=true
 )
 
-if [[ "$PHASE" =~ ^CLANG_ ]]; then
+if [[ "$PHASE" =~ CLANG ]]; then
     export CC=clang
     export CXX=clang++
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,14 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  # glibc + systemd-logind
+  fedora:
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:latest
       options: "--privileged"
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.phase }}
+      group: fedora-${{ github.workflow }}-${{ github.ref }}-${{ matrix.phase }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -36,4 +37,36 @@ jobs:
           dnf builddep -y polkit
 
       - name: Build & test
-        run: .github/workflows/ci.sh ${{ matrix.phase }}
+        run: .github/workflows/ci.sh ${{ matrix.phase }} logind
+
+  # musl + elogind
+  alpine:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+      options: "--privileged"
+    concurrency:
+      group: alpine-${{ github.workflow }}-${{ github.ref }}-${{ matrix.phase }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # There's no libasan/libubsan on Alpine, hence the missing GCC_ASAN_UBSAN phase
+        # See: https://gitlab.alpinelinux.org/alpine/aports/-/issues/10304
+        # Future FIXME: add clang + sanitizers to both jobs
+        phase: [BUILD_GCC, GCC, BUILD_CLANG, CLANG]
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+
+      - name: Install build & test dependencies
+        run: |
+          apk update
+          apk add bash gcc g++ clang meson ninja-build pkgconf glib-dev duktape-dev elogind-dev dbus-dev \
+                  expat-dev linux-pam-dev gobject-introspection-dev perl py3-dbusmock gtk-doc
+          # Alpine's elogind package creates compatibility symlinks to act as a drop-in replacement for
+          # systemd/systemd-logind. Remove them to test build with _pure_ elogind installation
+          rm -f /usr/include/systemd /usr/lib/pkgconfig/libsystemd{,-logind}.pc
+
+      - name: Build & test
+        run: .github/workflows/ci.sh ${{ matrix.phase }} elogind

--- a/src/polkit/polkitidentity.c
+++ b/src/polkit/polkitidentity.c
@@ -345,16 +345,9 @@ polkit_identity_new_for_gvariant (GVariant  *variant,
     }
   else if (g_strcmp0 (kind, "unix-netgroup") == 0)
     {
+#ifdef HAVE_SETNETGRENT
       GVariant *v;
       const char *name;
-
-#ifndef HAVE_SETNETGRENT
-      g_set_error (error,
-                   POLKIT_ERROR,
-                   POLKIT_ERROR_FAILED,
-                   "Netgroups are not available on this machine");
-      goto out;
-#else
 
       v = lookup_asv (details_gvariant, "name", G_VARIANT_TYPE_STRING, error);
       if (v == NULL)
@@ -365,6 +358,12 @@ polkit_identity_new_for_gvariant (GVariant  *variant,
       name = g_variant_get_string (v, NULL);
       ret = polkit_unix_netgroup_new (name);
       g_variant_unref (v);
+#else
+      g_set_error (error,
+                   POLKIT_ERROR,
+                   POLKIT_ERROR_FAILED,
+                   "Netgroups are not available on this machine");
+      goto out;
 #endif
     }
   else

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -1180,13 +1180,13 @@ js_polkit_spawn (duk_context *cx)
 static duk_ret_t
 js_polkit_user_is_in_netgroup (duk_context *cx)
 {
+  gboolean is_in_netgroup = FALSE;
+#ifdef HAVE_SETNETGRENT
   const char *user;
   const char *netgroup;
-  gboolean is_in_netgroup = FALSE;
 
   user = duk_require_string (cx, 0);
   netgroup = duk_require_string (cx, 1);
-#ifdef HAVE_SETNETGRENT
   if (innetgr (netgroup,
                NULL,  /* host */
                user,

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -2276,11 +2276,10 @@ static GList *
 get_users_in_net_group (PolkitIdentity                    *group,
                         gboolean                           include_root)
 {
-  const gchar *name;
-  GList *ret;
-
-  ret = NULL;
+  GList *ret = NULL;
 #ifdef HAVE_SETNETGRENT
+  const gchar *name;
+
   name = polkit_unix_netgroup_get_name (POLKIT_UNIX_NETGROUP (group));
 
 # ifdef HAVE_SETNETGRENT_RETURN

--- a/test/polkit/polkitunixnetgrouptest.c
+++ b/test/polkit/polkitunixnetgrouptest.c
@@ -23,7 +23,7 @@
 #include <polkit/polkit.h>
 #include <string.h>
 
-
+#ifdef HAVE_SETNETGRENT
 static void
 test_new (void)
 {
@@ -63,7 +63,7 @@ test_set_name (void)
 
   g_object_unref (netgroup);
 }
-
+#endif
 
 int
 main (int argc, char *argv[])

--- a/test/polkitbackend/test-polkitbackendjsauthority.c
+++ b/test/polkitbackend/test-polkitbackendjsauthority.c
@@ -268,6 +268,7 @@ static const RulesTestCase rules_test_cases[] = {
     POLKIT_IMPLICIT_AUTHORIZATION_NOT_AUTHORIZED,
   },
 
+#ifdef HAVE_SETNETGRENT
   /* check netgroup membership */
   {
     /* john is a member of netgroup 'foo', see test/etc/netgroup */
@@ -285,6 +286,7 @@ static const RulesTestCase rules_test_cases[] = {
     NULL,
     POLKIT_IMPLICIT_AUTHORIZATION_NOT_AUTHORIZED,
   },
+#endif
 
   /* spawning */
   {


### PR DESCRIPTION
Alpine uses musl + elogind, which should provide some additional
coverage, especially for issues like https://github.com/polkit-org/polkit/issues/539.

---

\+ a couple of fixes for build warnings/errors when building with musl.