### PR TITLE
ci: install newer meson for the Coverity job as well

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
         # polkit in Ubuntu Jammy (ATTOW) doesn't have the latest build dependencies yet
         sudo apt install -y duktape-dev python3-pip
 
-        # Ubuntu 22.04 ships only meson 1.3.4 (ATTOW), so install a newer one via pip
+        # Ubuntu 24.04 ships only meson 1.3.4 (ATTOW), so install a newer one via pip
         dpkg-query -W meson && sudo apt remove -y meson
         sudo pip3 install 'meson>=1.4.0'
         sudo meson --version

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -32,5 +32,10 @@ jobs:
           sudo apt update
           sudo apt build-dep -y policykit-1
 
+          # Ubuntu 24.04 ships only meson 1.3.4 (ATTOW), so install a newer one via pip
+          dpkg-query -W meson && sudo apt remove -y meson
+          sudo pip3 install 'meson>=1.4.0'
+          sudo meson --version
+
       - name: Build & upload the results
         run: .github/workflows/coverity.sh


### PR DESCRIPTION
Since it also runs on Ubuntu 24.04 which doesn't have new-enough meson.

Follow-up for 810b5dd863dbbb0a19c3613a1f5dd55c2e8ac886.

---

(Note: this is intentionally _not_ opened from a fork branch, so I can test the Coverity job indeed works as it needs access to repo tokens)