### PR TITLE
test: rewrite tests for realpath() shenanigans 

### DIFF
--- a/test/integration/pkexec/test.sh
+++ b/test/integration/pkexec/test.sh
@@ -16,8 +16,8 @@ at_exit() {
 
     : "Cleanup"
     userdel -rf "$TEST_USER"
-    systemctl restart polkit
     rm -rf "$TMP_DIR" "$TEST_RULES" "$TEST_ACTIONS"
+    systemctl restart polkit
 }
 
 trap at_exit EXIT


### PR DESCRIPTION
The second test tried to strace a setuid binary as an unprivileged user
which will never work, but the fact was hidden by missing strace on the
test machine. Let's rewrite the tests to fix this, and check a couple
more cases.

Follow-up for 9aa43e089d870a8ee695e625237c5b731b250678.