### PR TITLE
Fix musl compilation error on Alpine

### DIFF
--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -674,7 +674,7 @@ main (int argc, char *argv[])
           argv[n] = path_abs;
       }
     }
-#if _POSIX_C_SOURCE >= 200809L
+#if _XOPEN_SOURCE >= 700
   s = realpath(path, NULL);
 #else
   s = NULL;


### PR DESCRIPTION
Feature-test macro _XOPEN_SOURCE is said to be an equivalent to _POSIX_C_SOURCE and apparently is defined on Alpine.
