### PR TITLE
Fix musl compilation error on Alpine

### DIFF
--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -674,12 +674,8 @@ main (int argc, char *argv[])
           argv[n] = path_abs;
       }
     }
-#if _POSIX_C_SOURCE >= 200809L
+
   s = realpath(path, NULL);
-#else
-  s = NULL;
-# error We have to deal with realpath(3) PATH_MAX madness
-#endif
   if (s != NULL)
     {
       /* The called program resolved to the canonical location. We don't update


### PR DESCRIPTION
Disruptions between glibc and musl-(not-)predefined feature-test macros led to a decision to remove a check for POSIX standards older than 17 years. It makes no sense to test the existence of a macro that we explicitly define in meson.build either (shall we test for _GNU_SOURCE).
