### PR TITLE
Make tmpfiles respect configured group name and document security implications

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -60,8 +60,11 @@ if not get_option('libs-only')
     install_dir: pk_datadir / 'polkit-1'
   )
 
-  install_data(
-    'polkit-tmpfiles.conf',
-    install_dir: tmpfiles_dir
+  configure_file(
+    input: 'polkit-tmpfiles.conf.in',
+    output: '@BASENAME@',
+    configuration: service_conf,
+    install: true,
+    install_dir: tmpfiles_dir,
   )
 endif

--- a/data/polkit-tmpfiles.conf
+++ b/data/polkit-tmpfiles.conf
@@ -1,1 +1,0 @@
-d /etc/polkit-1/rules.d 0750 root polkitd - -

--- a/data/polkit-tmpfiles.conf.in
+++ b/data/polkit-tmpfiles.conf.in
@@ -1,1 +1,3 @@
+# Pre-create the subdirectory so that administrator cannot forget to set appropriate mode and ownership.
+# It should have as minimal privileges as possible to ensure polkitd cannot change .rules files if it gets hijacked.
 d /etc/polkit-1/rules.d 0750 root @polkitd_user@ - -

--- a/data/polkit-tmpfiles.conf.in
+++ b/data/polkit-tmpfiles.conf.in
@@ -1,0 +1,1 @@
+d /etc/polkit-1/rules.d 0750 root @polkitd_user@ - -


### PR DESCRIPTION
## Summary

Follow up to <https://github.com/polkit-org/polkit/pull/442#issuecomment-2692493869>.

- Make tmpfiles respect configured polkit group name
- Document the security implications for tmpfiles.d entry

## Detailed description and/or reproducer

### Make tmpfiles respect configured polkit group name

We allow changing the polkit daemon user through the `-Dpolkitd_user` Meson option.
When this is used, the tmpfiles.d config will refer to a non-existent group.
For example, NixOS builds polkit with `-Dpolkitd_user=polkituser`.

Let’s substitute the `polkitd_user` value into the config.

We do not have a separate option for the group name since, by convention,
the group name matches the user name. This is also enforced by our `sysusers.d` config:
https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html#u

### Document the security implications for tmpfiles.d entry

Quoting from <https://www.github.com/polkit-org/polkit/pull/442#issuecomment-2692718825>:

> The tmpfiles.d is used to create polkit subdirectory in /etc, because the directory needs specific ownership mode, it needs to be owned by root and only readable by root and polkitd group. This is for security reasons, so that polkit daemon cannot change .rules files in case of getting hijacked. It should have as minimal privileges as possible. The subdirectory is pre-created so no administrator omits to set the appropriate mode and ownership.
