### PR TITLE
polkit-agent-helper: set CollectMode=inactive-or-failed

### DIFF
--- a/data/polkit-agent-helper@.service.in
+++ b/data/polkit-agent-helper@.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Authorization Manager Agent Helper
 Documentation=man:polkit(8)
+CollectMode=inactive-or-failed
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Ensure that failed helper runs (eg: auth failure) do not leave units behind to accumulate

Follow-up for c007940054392b67b84b6044dda8a215040d8eb5
