### PR TITLE
Degraded state after wrong/cancelled auth

### DIFF
--- a/data/polkit-agent-helper@.service.in
+++ b/data/polkit-agent-helper@.service.in
@@ -7,6 +7,7 @@ Type=oneshot
 DeviceAllow=/dev/null rw
 DevicePolicy=strict
 ExecStart=@libprivdir@/polkit-agent-helper-1 --socket-activated
+SuccessExitStatus=2
 StandardInput=socket
 StandardOutput=socket
 LimitMEMLOCK=0

--- a/src/polkitagent/polkitagenthelper-pam.c
+++ b/src/polkitagent/polkitagenthelper-pam.c
@@ -87,6 +87,7 @@ main (int argc, char *argv[])
   int rc;
   int pidfd = -1;
   int uid = -1;
+  int errval = 1;
   const char *user_to_auth;
   char *user_to_auth_free = NULL;
   char *cookie = NULL;
@@ -226,6 +227,9 @@ main (int argc, char *argv[])
       const char *err;
       err = pam_strerror (pam_h, rc);
       fprintf (stderr, "polkit-agent-helper-1: pam_authenticate failed: %s\n", err);
+
+      /* if run via systemd socket, failed authentication won't taint the system using SuccessExitStatus=2*/
+      errval = 2;
       goto error;
     }
 
@@ -302,7 +306,7 @@ error:
 
   fprintf (stdout, "FAILURE\n");
   flush_and_wait();
-  return 1;
+  return errval;
 }
 
 static int


### PR DESCRIPTION
Wrong password/timeout/cancelled authentication makes helper service failed, sending systemd state to degraded. This is linked to a specific pam event in helper source and can be perceived as a correct finish of the program on failed user interaction.
