### PR TITLE
pkexec: also se $SUDO_UID/$SUDO_GID for compat with sudo

### DIFF
--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -926,6 +926,12 @@ main (int argc, char *argv[])
 
   s = g_strdup_printf ("%d", getuid ());
   g_ptr_array_add (saved_env, g_strdup ("PKEXEC_UID"));
+  g_ptr_array_add (saved_env, g_strdup (s));
+  g_ptr_array_add (saved_env, g_strdup ("SUDO_UID")); /* compat with sudo */
+  g_ptr_array_add (saved_env, s);
+
+  s = g_strdup_printf ("%d", getgid ());
+  g_ptr_array_add (saved_env, g_strdup ("SUDO_GID")); /* compat with sudo */
   g_ptr_array_add (saved_env, s);
 
   /* set the environment */


### PR DESCRIPTION
Various tools (including some in systemd) want to slightly change behaviour in case they detect they are invoked in a sudo or sudo-like context (for example disable certain security-sensitive interfaces). They currently mostly check $USER_UID to detect this situation, which will work for at least the sudo, run0, sudo-rs implementation of a privilege elevation tool. It doesn't work for pkexec however.

Let's change this, and for compatibility with sudo simply set the these two env vars too. This would increase compatibility for everyone in a simple, generic way.

Yes, it would be great if the env var would be more generically named than $SUDO_something, but I think at this point it shouldn't really matter, it's just a string.

Fixes: #561