### PR TITLE
Fix rapid leaking of large amounts of file descriptors

### DIFF
--- a/src/polkit/polkitunixprocess.c
+++ b/src/polkit/polkitunixprocess.c
@@ -1065,7 +1065,7 @@ polkit_unix_process_hash (PolkitSubject *subject)
 {
   PolkitUnixProcess *process = POLKIT_UNIX_PROCESS (subject);
 
-  return g_direct_hash (GSIZE_TO_POINTER ((polkit_unix_process_get_pid(process) + process->start_time))) ;
+  return g_direct_hash (GSIZE_TO_POINTER ((process->pid + process->start_time))) ;
 }
 
 static gboolean
@@ -1076,6 +1076,9 @@ polkit_unix_process_equal (PolkitSubject *a,
   PolkitUnixProcess *process_b;
   gint pid_a, pid_b;
   gint pidfd_a, pidfd_b;
+
+  if (a == b)
+    return TRUE;
 
   process_a = POLKIT_UNIX_PROCESS (a);
   process_b = POLKIT_UNIX_PROCESS (b);

--- a/src/polkit/polkitunixprocess.c
+++ b/src/polkit/polkitunixprocess.c
@@ -399,12 +399,15 @@ polkit_unix_process_constructed (GObject *object)
         GError *error;
         error = NULL;
 
-        process->ppidfd = get_ppidfd_for_pidfd (process->pidfd, &error);
-        if (error != NULL)
+        if (process->ppidfd < 0)
           {
-            g_error_free (error);
-            error = NULL;
-            process->ppidfd = -1;
+            process->ppidfd = get_ppidfd_for_pidfd (process->pidfd, &error);
+            if (error != NULL)
+              {
+                g_error_free (error);
+                error = NULL;
+                process->ppidfd = -1;
+              }
           }
 
         process->cgroupid = get_cgroupid_for_pidfd (process->pidfd, &error);

--- a/src/polkit/polkitunixprocess.c
+++ b/src/polkit/polkitunixprocess.c
@@ -840,7 +840,7 @@ polkit_unix_process_set_pid (PolkitUnixProcess *process,
     }
   if (pid > 0)
     {
-      gint pidfd = (int) syscall (SYS_pidfd_open, process->pid, 0);
+      gint pidfd = (int) syscall (SYS_pidfd_open, pid, 0);
       if (pidfd >= 0)
         {
           GError *error;


### PR DESCRIPTION
## Summary
Prevents polkit from leaking massive amounts (~10-20) of pidfds every invocation.


## Detailed description and/or reproducer
See individual commit messages for more details.

Tested using `run0` and a bpftrace script to monitor pidfd open/close for one invocation.

bpftrace script:
```bpftrace
tracepoint:syscalls:sys_exit_pidfd_open /comm == "polkitd" && args->ret > 0/ {
        @opener[args->ret] = ustack;
        @ispfd[args->ret] = 1;
        @ocnt[ustack]++;
}

tracepoint:syscalls:sys_enter_close /comm == "polkitd" && @ispfd[args->fd] == 1/ {
        if (--@ocnt[@opener[args->fd]] == 0) {
                delete(@ocnt[@opener[args->fd]]);
        }
        delete(@opener[args->fd]);
        delete(@ispfd[args->fd]);
}

END { clear(@ispfd); }
```

Before patch:
```
Attaching 3 probes...



@ocnt[
        syscall+29
        polkit_unix_process_set_pidfd+141
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        _polkit_subject_get_cmdline+147
        check_authorization_challenge_cb+148
        authentication_agent_begin_cb+164
        g_task_return_now+44
        g_task_return+304
        reply_cb+151
        g_task_return_now+44
        g_task_return+304
        g_dbus_connection_call_done+354
        g_task_return_now+44
        complete_in_idle_cb+21
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37
]: 1
@ocnt[
        syscall+29
        polkit_unix_process_set_pidfd+141
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        polkit_backend_interactive_authority_check_authorization+2145
        server_handle_method_call+569
        call_in_idle_cb+278
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37
]: 1
[lots of similar entries]
@ocnt[
        syscall+29
        polkit_unix_process_set_pidfd+141
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        convert_temporary_authorization_subject+85
        temporary_authorization_store_has_authorization+97
        check_authorization_sync+433
        check_authorization_sync+1453
        polkit_backend_interactive_authority_check_authorization+881
        server_handle_method_call+569
        call_in_idle_cb+278
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37
]: 1
@ocnt[
        syscall+29
        polkit_unix_process_set_pidfd+141
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        push_subject+934
        polkit_backend_common_js_authority_check_authorization_sync+292
        check_authorization_sync+385
        polkit_backend_interactive_authority_check_authorization+881
        server_handle_method_call+569
        call_in_idle_cb+278
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37
]: 25
@ocnt[
        syscall+29
        polkit_unix_process_set_pidfd+141
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        polkit_backend_session_monitor_get_session_for_subject.constprop.0+341
        check_authorization_sync+197
        polkit_backend_interactive_authority_check_authorization+881
        server_handle_method_call+569
        call_in_idle_cb+278
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37
]: 25
@opener[42]: 
        syscall+29
        polkit_unix_process_set_pidfd+141
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        polkit_backend_session_monitor_get_session_for_subject.constprop.0+341
        check_authorization_sync+197
        polkit_backend_interactive_authority_check_authorization+881
        server_handle_method_call+569
        call_in_idle_cb+278
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37
[lots of similar entries]
@opener[106]: 
        syscall+29
        polkit_unix_process_set_pidfd+141
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        push_subject+934
        polkit_backend_common_js_authority_check_authorization_sync+292
        check_authorization_sync+385
        polkit_backend_interactive_authority_check_authorization+881
        server_handle_method_call+569
        call_in_idle_cb+278
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37

```

After patch:
```
Attaching 3 probes...



@ocnt[
        syscall+29
        polkit_unix_process_set_pidfd+148
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        convert_temporary_authorization_subject+85
        check_authorization_challenge_cb+648
        authentication_agent_begin_cb+164
        g_task_return_now+44
        g_task_return+304
        reply_cb+151
        g_task_return_now+44
        g_task_return+304
        g_dbus_connection_call_done+354
        g_task_return_now+44
        complete_in_idle_cb+21
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37
]: 1
@opener[10]: 
        syscall+29
        polkit_unix_process_set_pidfd+148
        object_set_property+169
        g_object_new_internal.part.0+360
        g_object_new_valist+1595
        g_object_new+159
        polkit_unix_process_new_pidfd+70
        polkit_system_bus_name_get_process_sync+224
        convert_temporary_authorization_subject+85
        check_authorization_challenge_cb+648
        authentication_agent_begin_cb+164
        g_task_return_now+44
        g_task_return+304
        reply_cb+151
        g_task_return_now+44
        g_task_return+304
        g_dbus_connection_call_done+354
        g_task_return_now+44
        complete_in_idle_cb+21
        g_idle_dispatch+45
        g_main_context_dispatch_unlocked.lto_priv.0+464
        g_main_context_iterate_unlocked.isra.0+728
        g_main_loop_run+127
        main+1097
        __libc_start_call_main+117
        __libc_start_main_alias_1+136
        _start+37

```

From https://docs.gtk.org/gobject/vfunc.Object.constructed.html:
> The constructed function is called by g_object_new() as the final step of the object creation process. **At the point of the call, all construction properties have been set on the object.** The purpose of this call is to allow for object initialisation steps that can only be performed after construction properties have been set. constructed implementors should chain up to the constructed call of their parent class to allow it to complete its initialisation.
