### PR TITLE
Nested .policy files cause xml parsing overflow leading to crash

### DIFF
--- a/src/polkitbackend/polkitbackendactionpool.c
+++ b/src/polkitbackend/polkitbackendactionpool.c
@@ -739,6 +739,12 @@ _start (void *data, const char *el, const char **attr)
   guint num_attr;
   ParserData *pd = data;
 
+  if (pd->stack_depth < 0 || pd->stack_depth >= PARSER_MAX_DEPTH)
+    {
+      g_warning ("XML parsing reached max depth?");
+      goto error;
+    }
+
   for (num_attr = 0; attr[num_attr] != NULL; num_attr++)
     ;
 


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
XML .policy files with nesting deeper more than `PARSER_MAX_DEPTH` cause polkit to crash. It requires auth'ed user to put such file in monitored directories though.

Reported by Med Maatallah. Many thanks!


## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
