### PR TITLE
Early destroy of main context during source destroy causes deadlock

### DIFF
--- a/src/polkitbackend/polkitbackendcommon.c
+++ b/src/polkitbackend/polkitbackendcommon.c
@@ -63,7 +63,7 @@ utils_spawn_data_free (UtilsSpawnData *data)
                              (GSourceFunc) utils_child_watch_from_release_cb,
                              source,
                              (GDestroyNotify) g_source_destroy);
-      g_source_attach (source, data->main_context);
+      g_source_attach (source, g_main_context_ref(data->main_context));
       g_source_unref (source);
       data->child_pid = 0;
     }


### PR DESCRIPTION
It seems that main context is being destroyed in another thread while GAsyncResult instance is destroying g_source attached to the context. A reference to the context seems to be missing, so it is destroyed early during thread race.
This is rather a temporary fix until GAsyncResult is rewritten to GTask (with better documentation, hopefully), which might also clean the build log of deprecation warnings.

Fixes !568

## Summary
[short description of the problem and the change]: #



## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
