### PR TITLE
polkitd: fix zombie not reaped when js spawned process timed out

### DIFF
--- a/src/polkitbackend/polkitbackendcommon.c
+++ b/src/polkitbackend/polkitbackendcommon.c
@@ -63,7 +63,8 @@ utils_spawn_data_free (UtilsSpawnData *data)
                              (GSourceFunc) utils_child_watch_from_release_cb,
                              source,
                              NULL);
-      g_source_attach (source, data->main_context);
+      /* attach source to the global default main context */
+      g_source_attach (source, NULL);
       g_source_unref (source);
       data->child_pid = 0;
     }


### PR DESCRIPTION
In version 0.117, the patch https://github.com/polkit-org/polkit/commit/8638ec5cd534dcc616b68e5b0744c493c0c71dc9 was merged to fix the issue of "zombie not reaped when js spawned process timed out." However, in version 121, the patch https://github.com/polkit-org/polkit/commit/c7fc4e1b61f0fd82fc697c19c604af7e9fb291a2 reverted the previous fix, causing the issue of "Leaking zombie child processes" to resurface.

## Summary
[short description of the problem and the change]: #



## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
