### PR TITLE
Fix polkitd startup assertion when built with --prefix=/usr/local

### DIFF
--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -257,7 +257,10 @@ polkit_backend_common_js_authority_constructed (GObject *object)
       authority->priv->rules_dirs[0] = g_strdup (PACKAGE_SYSCONF_DIR "/polkit-1/rules.d");
       authority->priv->rules_dirs[1] = g_strdup ("/run/polkit-1/rules.d");
       authority->priv->rules_dirs[2] = g_strdup ("/usr/local/share/polkit-1/rules.d");
-      authority->priv->rules_dirs[3] = g_strdup (PACKAGE_DATA_DIR "/polkit-1/rules.d");
+      if (g_strcmp0 (PACKAGE_DATA_DIR, "/usr/local/share") != 0)
+        {
+          authority->priv->rules_dirs[3] = g_strdup (PACKAGE_DATA_DIR "/polkit-1/rules.d");
+        }
     }
 
   setup_file_monitors (authority);


### PR DESCRIPTION




## Summary
When configured with --prefix=/usr/local, polkitd would crash with an assertion failure in polkit_backend_common_rules_file_name_cmp() due to duplicate paths in the rules_dirs array. This happened because both the hardcoded path '/usr/local/share/polkit-1/rules.d' and PACKAGE_DATA_DIR '/polkit-1/rules.d' (which becomes '/usr/local/share/polkit-1/rules.d') were being added to the array, creating identical entries.



## Detailed description and/or reproducer
The fix prevents duplicate paths by checking if PACKAGE_DATA_DIR equals '/usr/local/share' before adding the PACKAGE_DATA_DIR path to the rules_dirs array. This ensures that when both paths would be identical, only one is added.

This resolves the assertion failure that occurred when polkitd tried to determine precedence between identical path entries during startup.

Fixes: https://github.com/polkit-org/polkit/issues/544
