### PR TITLE
Change how pkexec resolve the canonical location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+.cache
 .deps
 /*.bak
 /*.gcda

--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -19,6 +19,7 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
+#include "glib.h"
 #include <string.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -642,7 +643,7 @@ main (int argc, char *argv[])
           goto out;
         }
       /* If you change this, be sure to change the if (!command_line)
-	 case below too */
+	    case below too */
       command_line = g_strdup (path);
       shell_argv = g_ptr_array_new ();
       g_ptr_array_add (shell_argv, path);
@@ -675,7 +676,8 @@ main (int argc, char *argv[])
       }
     }
 
-  s = realpath(path, NULL);
+  s = g_canonicalize_filename(path, NULL);
+
   if (s != NULL)
     {
       /* The called program resolved to the canonical location. We don't update


### PR DESCRIPTION
## Summary
The way pkexec resolve the canonical location
make symlink-based scripts fail to work.

I just change the function used to canonicalize path variable.
realpath: resolve symlink and make path canonical.
g_canonicalize_filename: make path canonical, do not resolve symlink.

## Detailed description and/or reproducer
For example i have a simple bash script:

$ cat ./a.sh
#!/usr/bin/env bash
echo $0

And i make a soft link: ./b.sh -> ./a.sh

command `pkexec ./b.sh` will print `./a.sh`,
but it should print `./b.sh`.

I make this change because symlink-based scripts
need to know the last symlink preceding it (ex.
python-exec2).
