### PR TITLE
Update bug reporting references to GitHub across docs and build

### DIFF
--- a/docs/man/pkaction.xml
+++ b/docs/man/pkaction.xml
@@ -84,8 +84,7 @@
     <para>
       Please send bug reports to either the distribution or the
       polkit-devel mailing list,
-      see the link <ulink url="https://gitlab.freedesktop.org/polkit/polkit/-/issues/"/>
-      on how to subscribe.
+      see <ulink url="https://github.com/polkit-org/polkit#bugs-and-development"/>.
     </para>
   </refsect1>
 

--- a/docs/man/pkcheck.xml
+++ b/docs/man/pkcheck.xml
@@ -206,8 +206,7 @@ KEY3=VALUE3
     <para>
       Please send bug reports to either the distribution or the
       polkit-devel mailing list,
-      see the link <ulink url="https://gitlab.freedesktop.org/polkit/polkit/-/issues/"/>
-      on how to subscribe.
+      see <ulink url="https://github.com/polkit-org/polkit#bugs-and-development"/>.
     </para>
   </refsect1>
 

--- a/docs/man/pkexec.xml
+++ b/docs/man/pkexec.xml
@@ -266,8 +266,7 @@ for n in range(len(sys.argv)):
     <para>
       Please send bug reports to either the distribution or the
       polkit-devel mailing list,
-      see the link <ulink url="https://gitlab.freedesktop.org/polkit/polkit/-/issues/"/>
-      on how to subscribe.
+      see <ulink url="https://github.com/polkit-org/polkit#bugs-and-development"/>.
     </para>
   </refsect1>
 

--- a/docs/man/pkttyagent.xml
+++ b/docs/man/pkttyagent.xml
@@ -138,8 +138,7 @@
     <para>
       Please send bug reports to either the distribution or the
       polkit-devel mailing list,
-      see the link <ulink url="https://gitlab.freedesktop.org/polkit/polkit/-/issues/"/>
-      on how to subscribe.
+      see <ulink url="https://github.com/polkit-org/polkit#bugs-and-development"/>.
     </para>
   </refsect1>
 

--- a/docs/man/polkit.xml
+++ b/docs/man/polkit.xml
@@ -1009,8 +1009,7 @@ polkit.addRule(function(action, subject) {
     <para>
       Please send bug reports to either the distribution or the
       polkit-devel mailing list,
-      see the link <ulink url="https://gitlab.freedesktop.org/polkit/polkit/-/issues/"/>
-      on how to subscribe.
+      see <ulink url="https://github.com/polkit-org/polkit#bugs-and-development"/>.
     </para>
   </refsect1>
 

--- a/docs/man/polkitd.xml
+++ b/docs/man/polkitd.xml
@@ -66,8 +66,7 @@
     <para>
       Please send bug reports to either the distribution or the
       polkit-devel mailing list,
-      see the link <ulink url="https://gitlab.freedesktop.org/polkit/polkit/-/issues/"/>
-      on how to subscribe.
+      see <ulink url="https://github.com/polkit-org/polkit#bugs-and-development"/>.
     </para>
   </refsect1>
 

--- a/meson.build
+++ b/meson.build
@@ -70,9 +70,9 @@ config_data = configuration_data()
 # defines
 set_defines = [
   # package
-  ['PACKAGE_BUGREPORT', 'https://gitlab.freedesktop.org/polkit/polkit/-/issues/'],
+  ['PACKAGE_BUGREPORT', 'https://github.com/polkit-org/polkit#bugs-and-development'],
   ['PACKAGE_NAME', meson.project_name()],
-  ['PACKAGE_URL', 'http://www.freedesktop.org/wiki/Software/polkit'],
+  ['PACKAGE_URL', 'https://github.com/polkit-org/polkit'],
   ['PACKAGE_VERSION', pk_version],
   ['VERSION', pk_version],
   # i18n

--- a/po/Makevars
+++ b/po/Makevars
@@ -41,7 +41,7 @@ PACKAGE_GNU = no
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://gitlab.freedesktop.org/polkit/polkit/-/issues/
+MSGID_BUGS_ADDRESS = https://github.com/polkit-org/polkit#bugs-and-development
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.


### PR DESCRIPTION
- docs/man/{pkaction,pkcheck,pkexec,pkttyagent,polkit,polkitd}.xml: Update BUGS section link from gitlab.freedesktop.org to https://github.com/polkit-org/polkit#bugs-and-development

- meson.build:
  - PACKAGE_BUGREPORT → https://github.com/polkit-org/polkit#bugs-and-development
  - PACKAGE_URL → https://github.com/polkit-org/polkit

Fixes: #583