### PR TITLE
Revert changes from 9fe5347 as unwanted after fix-leaking-zombies patch

### DIFF
--- a/src/polkitbackend/polkitbackendcommon.c
+++ b/src/polkitbackend/polkitbackendcommon.c
@@ -62,7 +62,7 @@ utils_spawn_data_free (UtilsSpawnData *data)
       g_source_set_callback (source,
                              (GSourceFunc) utils_child_watch_from_release_cb,
                              source,
-                             NULL);
+                             (GDestroyNotify) g_source_destroy);
       /* attach source to the global default main context */
       g_source_attach (source, NULL);
       g_source_unref (source);


### PR DESCRIPTION
After application of fix-leaking-zombies, i.e. attaching the source to application's main context, the source needs to be properly destroyed again, hence calling g_source_destroy as a notification callback makes sense here and doesn't break tests.
