### PR TITLE
CheckAuthorization: return 'polkit.result' in the details dict

### DIFF
--- a/data/org.freedesktop.PolicyKit1.Authority.xml
+++ b/data/org.freedesktop.PolicyKit1.Authority.xml
@@ -132,7 +132,7 @@
       </annotation>
 
       <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict<String,String>:details">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details for the result or empty if not authorized. Known key/value-pairs include <literal>polkit.temporary_authorization_id</literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), <literal>polkit.retains_authorization_after_challenge</literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)) and <literal>polkit.lockdown</literal> (set to a non-empty string if the action is locked down)."/>
+        <annotation name="org.gtk.EggDBus.DocString" value="Details for the result or empty if not authorized. Known key/value-pairs include <literal>polkit.temporary_authorization_id</literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), <literal>polkit.retains_authorization_after_challenge</literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)), <literal>polkit.lockdown</literal> (set to a non-empty string if the action is locked down), <literal>polkit.result</literal> (Set to the string value of the polkit.Result enum, e.g.: <literal>auth_admin</literal>)."/>
       </annotation>
     </annotation>
 

--- a/docs/polkit/docbook-interface-org.freedesktop.PolicyKit1.Authority.xml
+++ b/docs/polkit/docbook-interface-org.freedesktop.PolicyKit1.Authority.xml
@@ -479,7 +479,7 @@ TRUE if the given <link linkend="eggdbus-struct-Subject">Subject</link> could be
     <term><literal>Dict&lt;String,String&gt; <structfield>details</structfield></literal></term>
     <listitem>
       <para>
-Details for the result. Known key/value-pairs include <literal>polkit.temporary_authorization_id</literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), <literal>polkit.retains_authorization_after_challenge</literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)), <literal>polkit.dismissed</literal> (Set to a non-empty string if the authentication dialog was dismissed by the user).
+Details for the result. Known key/value-pairs include <literal>polkit.temporary_authorization_id</literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), <literal>polkit.retains_authorization_after_challenge</literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)), <literal>polkit.dismissed</literal> (Set to a non-empty string if the authentication dialog was dismissed by the user), <literal>polkit.result</literal> (Set to the string value of the polkit.Result enum, e.g.: <literal>auth_admin</literal>).
       </para>
     </listitem>
   </varlistentry>

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -1050,6 +1050,8 @@ polkit_backend_common_js_authority_check_authorization_sync (PolkitBackendIntera
       goto out;
     }
 
+  polkit_details_insert (details, "polkit.result", ret_str);
+
   good = TRUE;
 
  out:

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -1270,6 +1270,8 @@ check_authorization_sync (PolkitBackendAuthority         *authority,
           polkit_details_insert (details, "polkit.retains_authorization_after_challenge", "1");
         }
 
+      polkit_details_insert (details, "polkit.result", polkit_implicit_authorization_to_string (implicit_authorization));
+
       result = polkit_authorization_result_new (FALSE, TRUE, details);
 
       /* return implicit_authorization so the caller can use an authentication agent if applicable */


### PR DESCRIPTION
Let callers know how the user was authorized. This is useful for example to be able to distinguish between an auth_self and an auth_admin, as the latter means the subject is more privileged than the former.

In systemd we can use this for the case where users can be implicitly allowed to manage their own resources, but not other users resources, unless they successfully authenticate as admins: https://github.com/systemd/systemd/pull/38911#issuecomment-3310030331