### PR TITLE
data: Install an XML catalog to define the policyconfig DTD in

### DIFF
--- a/actions/meson.build
+++ b/actions/meson.build
@@ -1,6 +1,6 @@
 policy = 'org.freedesktop.policykit.policy'
 
-i18n.merge_file(
+policy_file = i18n.merge_file(
   input: policy + '.in',
   output: '@BASENAME@',
   po_dir: po_dir,
@@ -8,3 +8,17 @@ i18n.merge_file(
   install: true,
   install_dir: pk_pkgactiondir,
 )
+
+xmllint = find_program('xmllint', required: false)
+if xmllint.found()
+  test(
+    'validate-actions', xmllint,
+    env: {
+      'XML_CATALOG_FILES': catalog_xml_uninstalled.full_path(),
+    },
+    args: [
+      '--nonet', '--noblanks', '--noout', '--valid',
+      policy_file,
+    ],
+  )
+endif

--- a/data/catalog.xml.in
+++ b/data/catalog.xml.in
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--
+  SPDX-License-Identifier: LGPL-2.1-or-later
+  SPDX-FileCopyrightText: 2025 GNOME Foundation, Inc.
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
+  <public publicId="-//freedesktop//DTD polkit Policy Configuration 1.0//EN" uri="@POLKIT_DTD_DIR@/policyconfig-1.dtd"/>
+  <system systemId="http://www.freedesktop.org/software/polkit/policyconfig-1.dtd" uri="@POLKIT_DTD_DIR@/policyconfig-1.dtd"/>
+</catalog>

--- a/data/meson.build
+++ b/data/meson.build
@@ -68,9 +68,17 @@ if not get_option('libs-only')
     install_dir: sysusers_dir,
   )
 
+  xml_dir = pk_datadir / 'polkit-1'
   install_data(
     'policyconfig-1.dtd',
-    install_dir: pk_datadir / 'polkit-1'
+    install_dir: xml_dir,
+  )
+
+  configure_file(
+    input: 'catalog.xml.in',
+    output: 'catalog.xml',
+    install_dir: xml_dir,
+    configuration: {'POLKIT_DTD_DIR': get_option('prefix') / xml_dir},
   )
 
   configure_file(

--- a/data/meson.build
+++ b/data/meson.build
@@ -81,6 +81,13 @@ if not get_option('libs-only')
     configuration: {'POLKIT_DTD_DIR': get_option('prefix') / xml_dir},
   )
 
+  catalog_xml_uninstalled = configure_file(
+    input: 'catalog.xml.in',
+    output: 'catalog.uninstalled.xml',
+    install: false,
+    configuration: {'POLKIT_DTD_DIR': meson.project_source_root() / 'data'},
+  )
+
   configure_file(
     input: 'polkit-tmpfiles.conf.in',
     output: '@BASENAME@',

--- a/data/meson.build
+++ b/data/meson.build
@@ -68,7 +68,7 @@ if not get_option('libs-only')
     install_dir: sysusers_dir,
   )
 
-  xml_dir = pk_datadir / 'polkit-1'
+  xml_dir = pk_datadir / 'xml' / 'polkit-1'
   install_data(
     'policyconfig-1.dtd',
     install_dir: xml_dir,

--- a/data/meson.build
+++ b/data/meson.build
@@ -20,6 +20,11 @@ configure_file(
   install_dir: dbus_policydir,
 )
 
+dbus_interface_files = files(
+  'org.freedesktop.PolicyKit1.AuthenticationAgent.xml',
+  'org.freedesktop.PolicyKit1.Authority.xml',
+)
+
 if enable_pam
   if os_type == 'debian' and pam_include == ''
     install_data(
@@ -95,4 +100,19 @@ if not get_option('libs-only')
     install: true,
     install_dir: tmpfiles_dir,
   )
+
+  xmllint = find_program('xmllint', required: false)
+  if xmllint.found()
+    dbus_prefix = dbus_dep.get_variable(pkgconfig: 'prefix')
+    test(
+      'validate-dbus-interfaces', xmllint,
+      env: {
+        'XML_CATALOG_FILES': join_paths(dbus_prefix, 'share', 'xml', 'dbus-1', 'catalog.xml'),
+      },
+      args: [
+        '--nonet', '--noblanks', '--noout', '--valid',
+        dbus_interface_files,
+      ],
+    )
+  endif
 endif

--- a/data/org.freedesktop.PolicyKit1.AuthenticationAgent.xml
+++ b/data/org.freedesktop.PolicyKit1.AuthenticationAgent.xml
@@ -5,13 +5,13 @@
 
   <interface name="org.freedesktop.PolicyKit1.AuthenticationAgent">
     <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authentication Agent Interface"/>
-    <annotation name="org.gtk.EggDBus.DocString" value="<para>This D-Bus interface is used for communication between the system-wide PolicyKit daemon and one or more authentication agents each running in a user session.</para><para>An authentication agent must implement this interface and register (passing the object path of the object implementing the interface) using the org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent() and org.freedesktop.PolicyKit1.Authority.UnregisterAuthenticationAgent() methods on the #org.freedesktop.PolicyKit1.Authority interface of the PolicyKit daemon.</para>"/>
+    <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>This D-Bus interface is used for communication between the system-wide PolicyKit daemon and one or more authentication agents each running in a user session.&lt;/para>&lt;para>An authentication agent must implement this interface and register (passing the object path of the object implementing the interface) using the org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent() and org.freedesktop.PolicyKit1.Authority.UnregisterAuthenticationAgent() methods on the #org.freedesktop.PolicyKit1.Authority interface of the PolicyKit daemon.&lt;/para>"/>
 
     <method name="BeginAuthentication">
-      <annotation name="org.gtk.EggDBus.DocString" value="<para>Called
+      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>Called
       by the PolicyKit daemon when the authentication agent needs the
       user to authenticate as one of the identities in @identities for
-      the action with the identifier @action_id.</para><para>This
+      the action with the identifier @action_id.&lt;/para>&lt;para>This
       authentication is normally achieved via the
       PolkitAgentSession API, which invokes a private
       setuid helper process to verify the authentication.  When
@@ -20,7 +20,7 @@
       method on the #org.freedesktop.PolicyKit1.Authority interface of
       the PolicyKit daemon before returning.  If the user dismisses the
       authentication dialog, the authentication agent should return an
-      error.</para>"/>
+      error.&lt;/para>"/>
 
       <arg name="action_id" direction="in" type="s">
         <annotation name="org.gtk.EggDBus.DocString" value="The identifier for the action that the user is authentication for."/>
@@ -43,7 +43,7 @@
       </arg>
 
       <arg name="identities" direction="in" type="a(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Array<Identity>"/>
+        <annotation name="org.gtk.EggDBus.Type" value="Array&lt;Identity>"/>
         <annotation name="org.gtk.EggDBus.DocString" value="An array of #Identity structs that the user can use for authentication."/>
       </arg>
     </method>

--- a/data/org.freedesktop.PolicyKit1.AuthenticationAgent.xml
+++ b/data/org.freedesktop.PolicyKit1.AuthenticationAgent.xml
@@ -4,56 +4,22 @@
 <node name="/">
 
   <interface name="org.freedesktop.PolicyKit1.AuthenticationAgent">
-    <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authentication Agent Interface"/>
-    <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>This D-Bus interface is used for communication between the system-wide PolicyKit daemon and one or more authentication agents each running in a user session.&lt;/para>&lt;para>An authentication agent must implement this interface and register (passing the object path of the object implementing the interface) using the org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent() and org.freedesktop.PolicyKit1.Authority.UnregisterAuthenticationAgent() methods on the #org.freedesktop.PolicyKit1.Authority interface of the PolicyKit daemon.&lt;/para>"/>
-
     <method name="BeginAuthentication">
-      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>Called
-      by the PolicyKit daemon when the authentication agent needs the
-      user to authenticate as one of the identities in @identities for
-      the action with the identifier @action_id.&lt;/para>&lt;para>This
-      authentication is normally achieved via the
-      PolkitAgentSession API, which invokes a private
-      setuid helper process to verify the authentication.  When
-      successful, it calls the
-      org.freedesktop.PolicyKit1.Authority.AuthenticationAgentResponse2()
-      method on the #org.freedesktop.PolicyKit1.Authority interface of
-      the PolicyKit daemon before returning.  If the user dismisses the
-      authentication dialog, the authentication agent should return an
-      error.&lt;/para>"/>
+      <arg name="action_id" direction="in" type="s"/>
 
-      <arg name="action_id" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The identifier for the action that the user is authentication for."/>
-      </arg>
+      <arg name="message" direction="in" type="s"/>
 
-      <arg name="message" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The message to display to the user. This is translated into the locale passed when registering the authentication agent using org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent()."/>
-      </arg>
+      <arg name="icon_name" direction="in" type="s"/>
 
-      <arg name="icon_name" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The themed icon describing the action or the empty string if no icon is set."/>
-      </arg>
+      <arg name="details" direction="in" type="a{ss}"/>
 
-      <arg name="details" direction="in" type="a{ss}">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details about the authentication request. This is a dictionary of key/value pairs where both key and value are strings. These strings are translated into the locale passed when registering the authentication agent using org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent()."/>
-      </arg>
+      <arg name="cookie" direction="in" type="s"/>
 
-      <arg name="cookie" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="A cookie identifying the authentication request."/>
-      </arg>
-
-      <arg name="identities" direction="in" type="a(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Array&lt;Identity>"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="An array of #Identity structs that the user can use for authentication."/>
-      </arg>
+      <arg name="identities" direction="in" type="a(sa{sv})"/>
     </method>
 
     <method name="CancelAuthentication">
-      <annotation name="org.gtk.EggDBus.DocString" value="Called by the PolicyKit daemon if the authentication agent needs to cancel an authentication dialog."/>
-
-      <arg name="cookie" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The cookie identifying the authentication request."/>
-      </arg>
+      <arg name="cookie" direction="in" type="s"/>
     </method>
 
   </interface>

--- a/data/org.freedesktop.PolicyKit1.Authority.xml
+++ b/data/org.freedesktop.PolicyKit1.Authority.xml
@@ -6,9 +6,6 @@
     <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authority Interface"/>
     <annotation name="org.gtk.EggDBus.DocString" value="This D-Bus interface is implemented by the <literal>/org/freedesktop/PoliycKit1/Authority</literal> object on the well-known name <literal>org.freedesktop.PolicyKit1</literal> on the system message bus."/>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
-    <!-- Subject struct -->
     <annotation name="org.gtk.EggDBus.DeclareStruct" value="Subject">
       <annotation name="org.gtk.EggDBus.DocString.Summary" value="Subjects"/>
       <annotation name="org.gtk.EggDBus.DocString" value="<para>This struct describes subjects such as UNIX processes. It is typically used to check if a given process is authorized for an action.</para><para>The following kinds of subjects are known:</para>
@@ -25,8 +22,6 @@
       </annotation>
 
     </annotation>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <!-- Identity struct -->
     <annotation name="org.gtk.EggDBus.DeclareStruct" value="Identity">
@@ -48,8 +43,6 @@
       <!-- TODO: document values in hash map for each identity type-->
 
     </annotation>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <!-- ActionDescription struct -->
     <annotation name="org.gtk.EggDBus.DeclareStruct" value="ActionDescription">
@@ -101,8 +94,6 @@
 
     </annotation>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
     <!-- Flags used for checking authorizations -->
     <annotation name="org.gtk.EggDBus.DeclareFlags" value="CheckAuthorizationFlags">
       <annotation name="org.gtk.EggDBus.DocString.Summary" value="Flags used when checking authorizations"/>
@@ -115,8 +106,6 @@
         <annotation name="org.gtk.EggDBus.DocString" value="Check access against policy even if the #Subject is the root user."/>
       </annotation>
     </annotation>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <!-- An structure containing the results of an authorization check -->
     <annotation name="org.gtk.EggDBus.DeclareStruct" value="AuthorizationResult">
@@ -135,8 +124,6 @@
         <annotation name="org.gtk.EggDBus.DocString" value="Details for the result or empty if not authorized. Known key/value-pairs include <literal>polkit.temporary_authorization_id</literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), <literal>polkit.retains_authorization_after_challenge</literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)) and <literal>polkit.lockdown</literal> (set to a non-empty string if the action is locked down)."/>
       </annotation>
     </annotation>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <!-- An enumeration for implicit authorizations -->
     <annotation name="org.gtk.EggDBus.DeclareEnum" value="ImplicitAuthorization">
@@ -169,8 +156,6 @@
 
     </annotation>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
     <!-- The error domain used for reporting errors -->
     <annotation name="org.gtk.EggDBus.DeclareErrorDomain" value="Error">
       <annotation name="org.gtk.EggDBus.DocString.Summary" value="Errors"/>
@@ -196,8 +181,6 @@
       </annotation>
     </annotation>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
     <!-- Flags describing what features the Authority implementation supports -->
     <annotation name="org.gtk.EggDBus.DeclareFlags" value="AuthorityFeatures">
       <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authority Features"/>
@@ -212,8 +195,6 @@
       </annotation>
     </annotation>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
     <property name="BackendName" type="s" access="read">
       <annotation name="org.gtk.EggDBus.DocString" value="The name of the currently used Authority backend."/>
     </property>
@@ -227,8 +208,6 @@
       <annotation name="org.gtk.EggDBus.DocString" value="The features supported by the currently used Authority backend."/>
     </property>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
     <method name="EnumerateActions">
       <annotation name="org.gtk.EggDBus.DocString" value="Enumerates all registered PolicyKit actions."/>
 
@@ -241,8 +220,6 @@
         <annotation name="org.gtk.EggDBus.DocString" value="An array of #ActionDescription structs."/>
       </arg>
     </method>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <method name="CheckAuthorization">
       <annotation name="org.gtk.EggDBus.DocString" value="<para>Checks if @subject is authorized to perform the action with identifier @action_id.</para><para>If @cancellation_id is non-empty and already in use for the caller, the %org.freedesktop.PolicyKit1.Error.CancellationIdNotUnique error is returned.</para><para>Note that %CheckAuthorizationFlags.AllowUserInteraction SHOULD be passed ONLY if the event that triggered the authorization check is stemming from an user action, e.g. the user pressing a button or attaching a device.</para>"/>
@@ -282,8 +259,6 @@
         <annotation name="org.gtk.EggDBus.DocString" value="The @cancellation_id passed to org.freedesktop.PolicyKit1.Authority.CheckAuthorization()."/>
       </arg>
     </method>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <method name="RegisterAuthenticationAgent">
       <annotation name="org.gtk.EggDBus.DocString" value="<para>Register an authentication agent.</para><para>Note that this should be called by the same effective UID which will be passed to org.freedesktop.PolicyKit1.Authority.AuthenticationAgentResponse2().</para>"/>
@@ -353,8 +328,6 @@ Must match the effective UID of the caller of org.freedesktop.PolicyKit1.Authori
       </arg>
     </method>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
     <!-- TemporaryAuthorization struct -->
     <annotation name="org.gtk.EggDBus.DeclareStruct" value="TemporaryAuthorization">
       <annotation name="org.gtk.EggDBus.DocString.Summary" value="Temporary Authorizations"/>
@@ -381,8 +354,6 @@ Must match the effective UID of the caller of org.freedesktop.PolicyKit1.Authori
         <annotation name="org.gtk.EggDBus.DocString" value="When the temporary authorization is set to expire, in seconds since the Epoch Jan 1, 1970 0:00 UTC."/>
       </annotation>
     </annotation>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <method name="EnumerateTemporaryAuthorizations">
       <annotation name="org.gtk.EggDBus.DocString" value="Retrieves all temporary authorizations that applies to @subject."/>
@@ -415,8 +386,6 @@ Must match the effective UID of the caller of org.freedesktop.PolicyKit1.Authori
       </arg>
     </method>
 
-    <!-- ---------------------------------------------------------------------------------------------------- -->
-
     <method name="AddLockdownForAction">
       <annotation name="org.gtk.EggDBus.DocString" value="Locks down an action so administrator authentication is always needed to obtain a temporary authorization for the action."/>
       <arg name="action_id" direction="in" type="s">
@@ -430,8 +399,6 @@ Must match the effective UID of the caller of org.freedesktop.PolicyKit1.Authori
         <annotation name="org.gtk.EggDBus.DocString" value="Identifier for the action."/>
       </arg>
     </method>
-
-    <!-- ---------------------------------------------------------------------------------------------------- -->
 
     <signal name="Changed">
       <annotation name="org.gtk.EggDBus.DocString" value="This signal is emitted when actions, sessions and/or authorizations change, carrying information about the change."/>

--- a/data/org.freedesktop.PolicyKit1.Authority.xml
+++ b/data/org.freedesktop.PolicyKit1.Authority.xml
@@ -3,406 +3,87 @@
 <node>
 
   <interface name="org.freedesktop.PolicyKit1.Authority">
-    <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authority Interface"/>
-    <annotation name="org.gtk.EggDBus.DocString" value="This D-Bus interface is implemented by the &lt;literal>/org/freedesktop/PoliycKit1/Authority&lt;/literal> object on the well-known name &lt;literal>org.freedesktop.PolicyKit1&lt;/literal> on the system message bus."/>
+    <property name="BackendName" type="s" access="read"/>
 
-    <annotation name="org.gtk.EggDBus.DeclareStruct" value="Subject">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Subjects"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>This struct describes subjects such as UNIX processes. It is typically used to check if a given process is authorized for an action.&lt;/para>&lt;para>The following kinds of subjects are known:&lt;/para>
-                  &lt;formalpara>&lt;title>Unix Process&lt;/title>&lt;para>&lt;literal>subject_kind&lt;/literal> should be set to &lt;literal>unix-process&lt;/literal> with keys &lt;literal>pidfd&lt;/literal> (of type &lt;literal>int32&lt;/literal>) and &lt;literal>uid&lt;/literal> (of type &lt;literal>int32&lt;/literal>) (if the operating system supports ProcessID File Descriptors), or alternatively with keys &lt;literal>pid&lt;/literal> (of type &lt;literal>uint32&lt;/literal>), &lt;literal>uid&lt;/literal> (of type &lt;literal>int32&lt;/literal>) and &lt;literal>start-time&lt;/literal> (of type &lt;literal>uint64&lt;/literal>).&lt;/para>&lt;/formalpara>
-                  &lt;formalpara>&lt;title>Unix Session&lt;/title>&lt;para>&lt;literal>subject_kind&lt;/literal> should be set to &lt;literal>unix-session&lt;/literal> with the key &lt;literal>session-id&lt;/literal> (of type &lt;literal>string&lt;/literal>).&lt;/para>&lt;/formalpara>
-                  &lt;formalpara>&lt;title>System Bus Name&lt;/title>&lt;para>&lt;literal>subject_kind&lt;/literal> should be set to &lt;literal>system-bus-name&lt;/literal> with the key &lt;literal>name&lt;/literal> (of type &lt;literal>string&lt;/literal>).&lt;/para>&lt;/formalpara>"/>
+    <property name="BackendVersion" type="s" access="read"/>
 
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:subject_kind">
-        <annotation name="org.gtk.EggDBus.DocString" value="The type of the subject."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,Variant>:subject_details">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details about the subject. Depending of the value of @subject_kind, a set of well-defined key/value pairs are guaranteed to be available."/>
-      </annotation>
-
-    </annotation>
-
-    <!-- Identity struct -->
-    <annotation name="org.gtk.EggDBus.DeclareStruct" value="Identity">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Identities"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>This struct describes identities such as UNIX users and UNIX groups. It is typically used to check if a given process is authorized for an action.&lt;/para>&lt;para>The following kinds of identities are known:&lt;/para>
-                  &lt;formalpara>&lt;title>Unix User&lt;/title>&lt;para>&lt;literal>identity_kind&lt;/literal> should be set to &lt;literal>unix-user&lt;/literal> with key &lt;literal>uid&lt;/literal> (of type &lt;literal>uint32&lt;/literal>).&lt;/para>&lt;/formalpara>
-                  &lt;formalpara>&lt;title>Unix Group&lt;/title>&lt;para>&lt;literal>identity_kind&lt;/literal> should be set to &lt;literal>unix-group&lt;/literal> with key &lt;literal>gid&lt;/literal> (of type &lt;literal>uint32&lt;/literal>).&lt;/para>&lt;/formalpara>
-
-"/>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:identity_kind">
-        <annotation name="org.gtk.EggDBus.DocString" value="Type of identity."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,Variant>:identity_details">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details about the identity. Depending of the value of @identity_kind, a set of well-defined key/value pairs are guaranteed to be available."/>
-      </annotation>
-
-      <!-- TODO: document values in hash map for each identity type-->
-
-    </annotation>
-
-    <!-- ActionDescription struct -->
-    <annotation name="org.gtk.EggDBus.DeclareStruct" value="ActionDescription">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Actions"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="This struct describes actions registered with the PolicyKit daemon."/>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:action_id">
-        <annotation name="org.gtk.EggDBus.DocString" value="Action Identifier."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:description">
-        <annotation name="org.gtk.EggDBus.DocString" value="Localized description of the action."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:message">
-        <annotation name="org.gtk.EggDBus.DocString" value="Localized message to be displayed when making the user authenticate for an action."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:vendor_name">
-        <annotation name="org.gtk.EggDBus.DocString" value="Name of the provider of the action or the empty string."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:vendor_url">
-        <annotation name="org.gtk.EggDBus.DocString" value="A URL pointing to a place with more information about the action or the empty string."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:icon_name">
-        <annotation name="org.gtk.EggDBus.DocString" value="The themed icon describing the action or the empty string if no icon is set."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="ImplicitAuthorization:implicit_any">
-        <annotation name="org.gtk.EggDBus.Type" value="ImplicitAuthorization"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="A value from the #ImplicitAuthorization enumeration for implicit authorizations that apply to any #Subject."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="ImplicitAuthorization:implicit_inactive">
-        <annotation name="org.gtk.EggDBus.Type" value="ImplicitAuthorization"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="A value from the #ImplicitAuthorization enumeration for implicit authorizations that apply any #Subject in an inactive user session on the local console."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="ImplicitAuthorization:implicit_active">
-        <annotation name="org.gtk.EggDBus.Type" value="ImplicitAuthorization"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="A value from the #ImplicitAuthorization enumeration for implicit authorizations that apply any #Subject in an active user session on the local console."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,String>:annotations">
-        <annotation name="org.gtk.EggDBus.DocString" value="Annotations for the action."/>
-      </annotation>
-
-    </annotation>
-
-    <!-- Flags used for checking authorizations -->
-    <annotation name="org.gtk.EggDBus.DeclareFlags" value="CheckAuthorizationFlags">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Flags used when checking authorizations"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="Flags used in the org.freedesktop.PolicyKit1.Authority.CheckAuthorization() method."/>
-
-      <annotation name="org.gtk.EggDBus.Flags.Member" value="AllowUserInteraction">
-        <annotation name="org.gtk.EggDBus.DocString" value="If the #Subject can obtain the authorization through authentication, and an authentication agent is available, then attempt to do so. Note, this means that the org.freedesktop.PolicyKit1.Authority.CheckAuthorization() method will block while the user is being asked to authenticate."/>
-      </annotation>
-      <annotation name="org.gtk.EggDBus.Flags.Member" value="AlwaysCheck">
-        <annotation name="org.gtk.EggDBus.DocString" value="Check access against policy even if the #Subject is the root user."/>
-      </annotation>
-    </annotation>
-
-    <!-- An structure containing the results of an authorization check -->
-    <annotation name="org.gtk.EggDBus.DeclareStruct" value="AuthorizationResult">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authorization Results"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="Describes the result of calling org.freedesktop.PolicyKit1.Authority.CheckAuthorization()."/>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Boolean:is_authorized">
-        <annotation name="org.gtk.EggDBus.DocString" value="TRUE if the given #Subject is authorized for the given action."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Boolean:is_challenge">
-        <annotation name="org.gtk.EggDBus.DocString" value="TRUE if the given #Subject could be authorized if more information was provided, and %CheckAuthorizationFlags.AllowUserInteraction wasn't passed or no suitable authentication agent was available."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,String>:details">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details for the result or empty if not authorized. Known key/value-pairs include &lt;literal>polkit.temporary_authorization_id&lt;/literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), &lt;literal>polkit.retains_authorization_after_challenge&lt;/literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)) and &lt;literal>polkit.lockdown&lt;/literal> (set to a non-empty string if the action is locked down)."/>
-      </annotation>
-    </annotation>
-
-    <!-- An enumeration for implicit authorizations -->
-    <annotation name="org.gtk.EggDBus.DeclareEnum" value="ImplicitAuthorization">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Implicit authorizations"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="An enumeration for granting implicit authorizations."/>
-
-      <annotation name="org.gtk.EggDBus.Enum.Member" value="NotAuthorized">
-        <annotation name="org.gtk.EggDBus.DocString" value="The #Subject is not authorized."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Enum.Member" value="AuthenticationRequired">
-        <annotation name="org.gtk.EggDBus.DocString" value="Authentication is required."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Enum.Member" value="AdministratorAuthenticationRequired">
-        <annotation name="org.gtk.EggDBus.DocString" value="Authentication as an administrator is required."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Enum.Member" value="AuthenticationRequiredRetained">
-        <annotation name="org.gtk.EggDBus.DocString" value="Authentication is required. If the authorization is obtained, it is retained."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Enum.Member" value="AdministratorAuthenticationRequiredRetained">
-        <annotation name="org.gtk.EggDBus.DocString" value="Authentication as an administrator is required. If the authorization is obtained, it is retained."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Enum.Member" value="Authorized">
-        <annotation name="org.gtk.EggDBus.DocString" value="The subject is authorized."/>
-      </annotation>
-
-    </annotation>
-
-    <!-- The error domain used for reporting errors -->
-    <annotation name="org.gtk.EggDBus.DeclareErrorDomain" value="Error">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Errors"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="Errors that can be returned by various method calls."/>
-
-      <annotation name="org.gtk.EggDBus.ErrorDomain.Member" value="org.freedesktop.PolicyKit1.Error.Failed">
-        <annotation name="org.gtk.EggDBus.DocString" value="The operation failed."/>
-      </annotation>
-      <annotation name="org.gtk.EggDBus.ErrorDomain.Member" value="org.freedesktop.PolicyKit1.Error.Cancelled">
-        <annotation name="org.gtk.EggDBus.DocString" value="The operation was cancelled."/>
-      </annotation>
-      <annotation name="org.gtk.EggDBus.ErrorDomain.Member" value="org.freedesktop.PolicyKit1.Error.NotSupported">
-        <annotation name="org.gtk.EggDBus.DocString" value="The operation is not supported."/>
-      </annotation>
-      <annotation name="org.gtk.EggDBus.ErrorDomain.Member" value="org.freedesktop.PolicyKit1.Error.NotAuthorized">
-        <annotation name="org.gtk.EggDBus.DocString" value="You are not authorized to perform the requested operation."/>
-      </annotation>
-
-      <!-- errors not exposed in GObject library follows here -->
-      <annotation name="org.gtk.EggDBus.ErrorDomain.Member" value="org.freedesktop.PolicyKit1.Error.CancellationIdNotUnique">
-        <annotation name="org.gtk.EggDBus.ErrorDomain.Member.Value" value="1000"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="The passed @cancellation_id is already in use."/>
-      </annotation>
-    </annotation>
-
-    <!-- Flags describing what features the Authority implementation supports -->
-    <annotation name="org.gtk.EggDBus.DeclareFlags" value="AuthorityFeatures">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authority Features"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="Flags describing features supported by the Authority implementation."/>
-
-      <annotation name="org.gtk.EggDBus.Flags.Member" value="TemporaryAuthorization">
-        <annotation name="org.gtk.EggDBus.DocString" value="The authority supports temporary authorizations that can be obtained through authentication."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Flags.Member" value="Lockdown">
-        <annotation name="org.gtk.EggDBus.DocString" value="The authority supports the org.freedesktop.PolicyKit1.Authority.AddLockdownForAction() and org.freedesktop.PolicyKit1.Authority.RemoveLockdownForAction() methods."/>
-      </annotation>
-    </annotation>
-
-    <property name="BackendName" type="s" access="read">
-      <annotation name="org.gtk.EggDBus.DocString" value="The name of the currently used Authority backend."/>
-    </property>
-
-    <property name="BackendVersion" type="s" access="read">
-      <annotation name="org.gtk.EggDBus.DocString" value="The version of the currently used Authority backend."/>
-    </property>
-
-    <property name="BackendFeatures" type="u" access="read">
-      <annotation name="org.gtk.EggDBus.Type" value="AuthorityFeatures"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="The features supported by the currently used Authority backend."/>
-    </property>
+    <property name="BackendFeatures" type="u" access="read"/>
 
     <method name="EnumerateActions">
-      <annotation name="org.gtk.EggDBus.DocString" value="Enumerates all registered PolicyKit actions."/>
+      <arg name="locale" direction="in" type="s"/>
 
-      <arg name="locale" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The locale to get descriptions in or the blank string to use the system locale."/>
-      </arg>
-
-      <arg name="action_descriptions" direction="out" type="a(ssssssuuua{ss})">
-        <annotation name="org.gtk.EggDBus.Type" value="Array&lt;ActionDescription>"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="An array of #ActionDescription structs."/>
-      </arg>
+      <arg name="action_descriptions" direction="out" type="a(ssssssuuua{ss})"/>
     </method>
 
     <method name="CheckAuthorization">
-      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>Checks if @subject is authorized to perform the action with identifier @action_id.&lt;/para>&lt;para>If @cancellation_id is non-empty and already in use for the caller, the %org.freedesktop.PolicyKit1.Error.CancellationIdNotUnique error is returned.&lt;/para>&lt;para>Note that %CheckAuthorizationFlags.AllowUserInteraction SHOULD be passed ONLY if the event that triggered the authorization check is stemming from an user action, e.g. the user pressing a button or attaching a device.&lt;/para>"/>
+      <arg name="subject" direction="in" type="(sa{sv})"/>
 
-      <arg name="subject" direction="in" type="(sa{sv})">
-        <annotation name="org.gtk.EggDBus.DocString" value="A #Subject struct."/>
-        <annotation name="org.gtk.EggDBus.Type" value="Subject"/>
-      </arg>
+      <arg name="action_id" direction="in" type="s"/>
 
-      <arg name="action_id" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="Identifier for the action that @subject is attempting to do."/>
-      </arg>
+      <arg name="details" direction="in" type="a{ss}"/>
 
-      <arg name="details" direction="in" type="a{ss}">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details describing the action. Keys starting with &lt;literal>polkit.&lt;/literal> are reserved for internal use and cannot be used."/>
-      </arg>
+      <arg name="flags" direction="in" type="u"/>
 
-      <arg name="flags" direction="in" type="u">
-        <annotation name="org.gtk.EggDBus.Type" value="CheckAuthorizationFlags"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="A set of #CheckAuthorizationFlags."/>
-      </arg>
+      <arg name="cancellation_id" direction="in" type="s"/>
 
-      <arg name="cancellation_id" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="A unique id used to cancel the the authentication check via org.freedesktop.PolicyKit1.Authority.CancelCheckAuthorization() or the empty string if cancellation is not needed."/>
-      </arg>
-
-      <arg name="result" direction="out" type="(bba{ss})">
-        <annotation name="org.gtk.EggDBus.Type" value="AuthorizationResult"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="An #AuthorizationResult structure."/>
-      </arg>
+      <arg name="result" direction="out" type="(bba{ss})"/>
     </method>
 
     <method name="CancelCheckAuthorization">
-      <annotation name="org.gtk.EggDBus.DocString" value="Cancels an authorization check."/>
-
-      <arg name="cancellation_id" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The @cancellation_id passed to org.freedesktop.PolicyKit1.Authority.CheckAuthorization()."/>
-      </arg>
+      <arg name="cancellation_id" direction="in" type="s"/>
     </method>
 
     <method name="RegisterAuthenticationAgent">
-      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>Register an authentication agent.&lt;/para>&lt;para>Note that this should be called by the same effective UID which will be passed to org.freedesktop.PolicyKit1.Authority.AuthenticationAgentResponse2().&lt;/para>"/>
+      <arg name="subject" direction="in" type="(sa{sv})"/>
 
-      <arg name="subject" direction="in" type="(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Subject"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="The subject to register the authentication agent for, typically a session subject."/>
-      </arg>
+      <arg name="locale" direction="in" type="s"/>
 
-      <arg name="locale" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The locale of the authentication agent."/>
-      </arg>
-
-      <arg name="object_path" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The object path of authentication agent object on the unique name of the caller."/>
-      </arg>
+      <arg name="object_path" direction="in" type="s"/>
     </method>
 
     <method name="UnregisterAuthenticationAgent">
-      <annotation name="org.gtk.EggDBus.DocString" value="Unregister an authentication agent."/>
+      <arg name="subject" direction="in" type="(sa{sv})"/>
 
-      <arg name="subject" direction="in" type="(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Subject"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="The @subject passed to org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent()."/>
-      </arg>
-
-      <arg name="object_path" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The @object_path passed to org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent()."/>
-      </arg>
+      <arg name="object_path" direction="in" type="s"/>
     </method>
 
     <method name="AuthenticationAgentResponse">
-      <annotation name="org.gtk.EggDBus.DocString" value="Method for authentication agents to invoke on successful
-authentication, intended only for use by a privileged helper process
-internal to polkit. This method will fail unless a sufficiently privileged
-caller invokes it. Deprecated in favor of org.freedesktop.PolicyKit1.Authority.AuthenticationAgentResponse2."/>
+      <arg name="cookie" direction="in" type="s"/>
 
-      <arg name="cookie" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The cookie identifying the authentication request that was passed to the authentication agent."/>
-      </arg>
-
-      <arg name="identity" direction="in" type="(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Identity"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="A #Identity struct describing what identity was authenticated."/>
-      </arg>
+      <arg name="identity" direction="in" type="(sa{sv})"/>
     </method>
 
     <method name="AuthenticationAgentResponse2">
-      <annotation name="org.gtk.EggDBus.DocString" value="Method for authentication agents to invoke on successful
-authentication, intended only for use by a privileged helper process
-internal to polkit. This method will fail unless a sufficiently privileged
-caller invokes it. Note this method was added in 0.114, and should be preferred over org.freedesktop.PolicyKit1.Authority.AuthenticationAgentResponse()
-as it fixes a security issue."/>
+      <arg name="uid" direction="in" type="u"/>
 
-      <arg name="uid" direction="in" type="u">
-        <annotation name="org.gtk.EggDBus.DocString" value="The real uid of the agent.  Normally set by the setuid helper program.
-Must match the effective UID of the caller of org.freedesktop.PolicyKit1.Authority.RegisterAuthenticationAgent()."/>
-      </arg>
+      <arg name="cookie" direction="in" type="s"/>
 
-      <arg name="cookie" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The cookie identifying the authentication request that was passed to the authentication agent."/>
-      </arg>
-
-      <arg name="identity" direction="in" type="(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Identity"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="A #Identity struct describing what identity was authenticated."/>
-      </arg>
+      <arg name="identity" direction="in" type="(sa{sv})"/>
     </method>
 
-    <!-- TemporaryAuthorization struct -->
-    <annotation name="org.gtk.EggDBus.DeclareStruct" value="TemporaryAuthorization">
-      <annotation name="org.gtk.EggDBus.DocString.Summary" value="Temporary Authorizations"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="This struct describes a temporary authorization."/>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:id">
-        <annotation name="org.gtk.EggDBus.DocString" value="An opaque identifier for the temporary authorization."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:action_id">
-        <annotation name="org.gtk.EggDBus.DocString" value="The action the temporary authorization is for."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Subject:subject">
-        <annotation name="org.gtk.EggDBus.Type" value="Subject"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="The subject the temporary authorization is for."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="UInt64:time_obtained">
-        <annotation name="org.gtk.EggDBus.DocString" value="When the temporary authorization was obtained, in seconds since the Epoch Jan 1, 1970 0:00 UTC."/>
-      </annotation>
-
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="UInt64:time_expires">
-        <annotation name="org.gtk.EggDBus.DocString" value="When the temporary authorization is set to expire, in seconds since the Epoch Jan 1, 1970 0:00 UTC."/>
-      </annotation>
-    </annotation>
-
     <method name="EnumerateTemporaryAuthorizations">
-      <annotation name="org.gtk.EggDBus.DocString" value="Retrieves all temporary authorizations that applies to @subject."/>
+      <arg name="subject" direction="in" type="(sa{sv})"/>
 
-      <arg name="subject" direction="in" type="(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Subject"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="The subject to get temporary authorizations for."/>
-      </arg>
-
-      <arg name="temporary_authorizations" direction="out" type="a(ss(sa{sv})tt)">
-        <annotation name="org.gtk.EggDBus.Type" value="Array&lt;TemporaryAuthorization>"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="An array of #TemporaryAuthorization structs."/>
-      </arg>
+      <arg name="temporary_authorizations" direction="out" type="a(ss(sa{sv})tt)"/>
     </method>
 
     <method name="RevokeTemporaryAuthorizations">
-      <annotation name="org.gtk.EggDBus.DocString" value="Revokes all temporary authorizations that applies to @subject."/>
-
-      <arg name="subject" direction="in" type="(sa{sv})">
-        <annotation name="org.gtk.EggDBus.Type" value="Subject"/>
-        <annotation name="org.gtk.EggDBus.DocString" value="The subject to revoke temporary authorizations from."/>
-      </arg>
+      <arg name="subject" direction="in" type="(sa{sv})"/>
     </method>
 
     <method name="RevokeTemporaryAuthorizationById">
-      <annotation name="org.gtk.EggDBus.DocString" value="Revokes all temporary authorizations that applies to @subject."/>
-
-      <arg name="id" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="The opaque identifier of the temporary authorization."/>
-      </arg>
+      <arg name="id" direction="in" type="s"/>
     </method>
 
     <method name="AddLockdownForAction">
-      <annotation name="org.gtk.EggDBus.DocString" value="Locks down an action so administrator authentication is always needed to obtain a temporary authorization for the action."/>
-      <arg name="action_id" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="Identifier for the action."/>
-      </arg>
+      <arg name="action_id" direction="in" type="s"/>
     </method>
 
     <method name="RemoveLockdownForAction">
-      <annotation name="org.gtk.EggDBus.DocString" value="Removes the effect of a previous org.freedesktop.PolicyKit1.Authority.AddLockdownForAction() call."/>
-      <arg name="action_id" direction="in" type="s">
-        <annotation name="org.gtk.EggDBus.DocString" value="Identifier for the action."/>
-      </arg>
+      <arg name="action_id" direction="in" type="s"/>
     </method>
 
-    <signal name="Changed">
-      <annotation name="org.gtk.EggDBus.DocString" value="This signal is emitted when actions, sessions and/or authorizations change, carrying information about the change."/>
-    </signal>
+    <signal name="Changed"/>
 
   </interface>
 </node>

--- a/data/org.freedesktop.PolicyKit1.Authority.xml
+++ b/data/org.freedesktop.PolicyKit1.Authority.xml
@@ -4,20 +4,20 @@
 
   <interface name="org.freedesktop.PolicyKit1.Authority">
     <annotation name="org.gtk.EggDBus.DocString.Summary" value="Authority Interface"/>
-    <annotation name="org.gtk.EggDBus.DocString" value="This D-Bus interface is implemented by the <literal>/org/freedesktop/PoliycKit1/Authority</literal> object on the well-known name <literal>org.freedesktop.PolicyKit1</literal> on the system message bus."/>
+    <annotation name="org.gtk.EggDBus.DocString" value="This D-Bus interface is implemented by the &lt;literal>/org/freedesktop/PoliycKit1/Authority&lt;/literal> object on the well-known name &lt;literal>org.freedesktop.PolicyKit1&lt;/literal> on the system message bus."/>
 
     <annotation name="org.gtk.EggDBus.DeclareStruct" value="Subject">
       <annotation name="org.gtk.EggDBus.DocString.Summary" value="Subjects"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="<para>This struct describes subjects such as UNIX processes. It is typically used to check if a given process is authorized for an action.</para><para>The following kinds of subjects are known:</para>
-                  <formalpara><title>Unix Process</title><para><literal>subject_kind</literal> should be set to <literal>unix-process</literal> with keys <literal>pidfd</literal> (of type <literal>int32</literal>) and <literal>uid</literal> (of type <literal>int32</literal>) (if the operating system supports ProcessID File Descriptors), or alternatively with keys <literal>pid</literal> (of type <literal>uint32</literal>), <literal>uid</literal> (of type <literal>int32</literal>) and <literal>start-time</literal> (of type <literal>uint64</literal>).</para></formalpara>
-                  <formalpara><title>Unix Session</title><para><literal>subject_kind</literal> should be set to <literal>unix-session</literal> with the key <literal>session-id</literal> (of type <literal>string</literal>).</para></formalpara>
-                  <formalpara><title>System Bus Name</title><para><literal>subject_kind</literal> should be set to <literal>system-bus-name</literal> with the key <literal>name</literal> (of type <literal>string</literal>).</para></formalpara>"/>
+      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>This struct describes subjects such as UNIX processes. It is typically used to check if a given process is authorized for an action.&lt;/para>&lt;para>The following kinds of subjects are known:&lt;/para>
+                  &lt;formalpara>&lt;title>Unix Process&lt;/title>&lt;para>&lt;literal>subject_kind&lt;/literal> should be set to &lt;literal>unix-process&lt;/literal> with keys &lt;literal>pidfd&lt;/literal> (of type &lt;literal>int32&lt;/literal>) and &lt;literal>uid&lt;/literal> (of type &lt;literal>int32&lt;/literal>) (if the operating system supports ProcessID File Descriptors), or alternatively with keys &lt;literal>pid&lt;/literal> (of type &lt;literal>uint32&lt;/literal>), &lt;literal>uid&lt;/literal> (of type &lt;literal>int32&lt;/literal>) and &lt;literal>start-time&lt;/literal> (of type &lt;literal>uint64&lt;/literal>).&lt;/para>&lt;/formalpara>
+                  &lt;formalpara>&lt;title>Unix Session&lt;/title>&lt;para>&lt;literal>subject_kind&lt;/literal> should be set to &lt;literal>unix-session&lt;/literal> with the key &lt;literal>session-id&lt;/literal> (of type &lt;literal>string&lt;/literal>).&lt;/para>&lt;/formalpara>
+                  &lt;formalpara>&lt;title>System Bus Name&lt;/title>&lt;para>&lt;literal>subject_kind&lt;/literal> should be set to &lt;literal>system-bus-name&lt;/literal> with the key &lt;literal>name&lt;/literal> (of type &lt;literal>string&lt;/literal>).&lt;/para>&lt;/formalpara>"/>
 
       <annotation name="org.gtk.EggDBus.Struct.Member"  value="String:subject_kind">
         <annotation name="org.gtk.EggDBus.DocString" value="The type of the subject."/>
       </annotation>
 
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict<String,Variant>:subject_details">
+      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,Variant>:subject_details">
         <annotation name="org.gtk.EggDBus.DocString" value="Details about the subject. Depending of the value of @subject_kind, a set of well-defined key/value pairs are guaranteed to be available."/>
       </annotation>
 
@@ -26,9 +26,9 @@
     <!-- Identity struct -->
     <annotation name="org.gtk.EggDBus.DeclareStruct" value="Identity">
       <annotation name="org.gtk.EggDBus.DocString.Summary" value="Identities"/>
-      <annotation name="org.gtk.EggDBus.DocString" value="<para>This struct describes identities such as UNIX users and UNIX groups. It is typically used to check if a given process is authorized for an action.</para><para>The following kinds of identities are known:</para>
-                  <formalpara><title>Unix User</title><para><literal>identity_kind</literal> should be set to <literal>unix-user</literal> with key <literal>uid</literal> (of type <literal>uint32</literal>).</para></formalpara>
-                  <formalpara><title>Unix Group</title><para><literal>identity_kind</literal> should be set to <literal>unix-group</literal> with key <literal>gid</literal> (of type <literal>uint32</literal>).</para></formalpara>
+      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>This struct describes identities such as UNIX users and UNIX groups. It is typically used to check if a given process is authorized for an action.&lt;/para>&lt;para>The following kinds of identities are known:&lt;/para>
+                  &lt;formalpara>&lt;title>Unix User&lt;/title>&lt;para>&lt;literal>identity_kind&lt;/literal> should be set to &lt;literal>unix-user&lt;/literal> with key &lt;literal>uid&lt;/literal> (of type &lt;literal>uint32&lt;/literal>).&lt;/para>&lt;/formalpara>
+                  &lt;formalpara>&lt;title>Unix Group&lt;/title>&lt;para>&lt;literal>identity_kind&lt;/literal> should be set to &lt;literal>unix-group&lt;/literal> with key &lt;literal>gid&lt;/literal> (of type &lt;literal>uint32&lt;/literal>).&lt;/para>&lt;/formalpara>
 
 "/>
 
@@ -36,7 +36,7 @@
         <annotation name="org.gtk.EggDBus.DocString" value="Type of identity."/>
       </annotation>
 
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict<String,Variant>:identity_details">
+      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,Variant>:identity_details">
         <annotation name="org.gtk.EggDBus.DocString" value="Details about the identity. Depending of the value of @identity_kind, a set of well-defined key/value pairs are guaranteed to be available."/>
       </annotation>
 
@@ -88,7 +88,7 @@
         <annotation name="org.gtk.EggDBus.DocString" value="A value from the #ImplicitAuthorization enumeration for implicit authorizations that apply any #Subject in an active user session on the local console."/>
       </annotation>
 
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict<String,String>:annotations">
+      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,String>:annotations">
         <annotation name="org.gtk.EggDBus.DocString" value="Annotations for the action."/>
       </annotation>
 
@@ -120,8 +120,8 @@
         <annotation name="org.gtk.EggDBus.DocString" value="TRUE if the given #Subject could be authorized if more information was provided, and %CheckAuthorizationFlags.AllowUserInteraction wasn't passed or no suitable authentication agent was available."/>
       </annotation>
 
-      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict<String,String>:details">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details for the result or empty if not authorized. Known key/value-pairs include <literal>polkit.temporary_authorization_id</literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), <literal>polkit.retains_authorization_after_challenge</literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)) and <literal>polkit.lockdown</literal> (set to a non-empty string if the action is locked down)."/>
+      <annotation name="org.gtk.EggDBus.Struct.Member"  value="Dict&lt;String,String>:details">
+        <annotation name="org.gtk.EggDBus.DocString" value="Details for the result or empty if not authorized. Known key/value-pairs include &lt;literal>polkit.temporary_authorization_id&lt;/literal> (if the authorization is temporary, this is set to the opaque temporary authorization id), &lt;literal>polkit.retains_authorization_after_challenge&lt;/literal> (Set to a non-empty string if the authorization will be retained after authentication (if is_challenge is TRUE)) and &lt;literal>polkit.lockdown&lt;/literal> (set to a non-empty string if the action is locked down)."/>
       </annotation>
     </annotation>
 
@@ -216,13 +216,13 @@
       </arg>
 
       <arg name="action_descriptions" direction="out" type="a(ssssssuuua{ss})">
-        <annotation name="org.gtk.EggDBus.Type" value="Array<ActionDescription>"/>
+        <annotation name="org.gtk.EggDBus.Type" value="Array&lt;ActionDescription>"/>
         <annotation name="org.gtk.EggDBus.DocString" value="An array of #ActionDescription structs."/>
       </arg>
     </method>
 
     <method name="CheckAuthorization">
-      <annotation name="org.gtk.EggDBus.DocString" value="<para>Checks if @subject is authorized to perform the action with identifier @action_id.</para><para>If @cancellation_id is non-empty and already in use for the caller, the %org.freedesktop.PolicyKit1.Error.CancellationIdNotUnique error is returned.</para><para>Note that %CheckAuthorizationFlags.AllowUserInteraction SHOULD be passed ONLY if the event that triggered the authorization check is stemming from an user action, e.g. the user pressing a button or attaching a device.</para>"/>
+      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>Checks if @subject is authorized to perform the action with identifier @action_id.&lt;/para>&lt;para>If @cancellation_id is non-empty and already in use for the caller, the %org.freedesktop.PolicyKit1.Error.CancellationIdNotUnique error is returned.&lt;/para>&lt;para>Note that %CheckAuthorizationFlags.AllowUserInteraction SHOULD be passed ONLY if the event that triggered the authorization check is stemming from an user action, e.g. the user pressing a button or attaching a device.&lt;/para>"/>
 
       <arg name="subject" direction="in" type="(sa{sv})">
         <annotation name="org.gtk.EggDBus.DocString" value="A #Subject struct."/>
@@ -234,7 +234,7 @@
       </arg>
 
       <arg name="details" direction="in" type="a{ss}">
-        <annotation name="org.gtk.EggDBus.DocString" value="Details describing the action. Keys starting with <literal>polkit.</literal> are reserved for internal use and cannot be used."/>
+        <annotation name="org.gtk.EggDBus.DocString" value="Details describing the action. Keys starting with &lt;literal>polkit.&lt;/literal> are reserved for internal use and cannot be used."/>
       </arg>
 
       <arg name="flags" direction="in" type="u">
@@ -261,7 +261,7 @@
     </method>
 
     <method name="RegisterAuthenticationAgent">
-      <annotation name="org.gtk.EggDBus.DocString" value="<para>Register an authentication agent.</para><para>Note that this should be called by the same effective UID which will be passed to org.freedesktop.PolicyKit1.Authority.AuthenticationAgentResponse2().</para>"/>
+      <annotation name="org.gtk.EggDBus.DocString" value="&lt;para>Register an authentication agent.&lt;/para>&lt;para>Note that this should be called by the same effective UID which will be passed to org.freedesktop.PolicyKit1.Authority.AuthenticationAgentResponse2().&lt;/para>"/>
 
       <arg name="subject" direction="in" type="(sa{sv})">
         <annotation name="org.gtk.EggDBus.Type" value="Subject"/>
@@ -364,7 +364,7 @@ Must match the effective UID of the caller of org.freedesktop.PolicyKit1.Authori
       </arg>
 
       <arg name="temporary_authorizations" direction="out" type="a(ss(sa{sv})tt)">
-        <annotation name="org.gtk.EggDBus.Type" value="Array<TemporaryAuthorization>"/>
+        <annotation name="org.gtk.EggDBus.Type" value="Array&lt;TemporaryAuthorization>"/>
         <annotation name="org.gtk.EggDBus.DocString" value="An array of #TemporaryAuthorization structs."/>
       </arg>
     </method>

--- a/meson.build
+++ b/meson.build
@@ -392,8 +392,8 @@ add_project_arguments(compiler_common_flags + compiler_cpp_flags, language: 'cpp
 
 content_files = files('COPYING')
 
-subdir('actions')
 subdir('data')
+subdir('actions')
 subdir('src')
 subdir('docs')
 subdir('po')


### PR DESCRIPTION
This allows tools like `xmllint` to look up the installed copy of the
DTD using its public ID, which allows offline validation of policyconfig
files in third-party projects without having to have network access to
download the DTD from
http://www.freedesktop.org/software/polkit/policyconfig-1.dtd.

For example:
```
XML_CATALOG_FILES=/usr/share/polkit-1/catalog.xml xmllint \
  --nonet --noblanks --noout --valid ./my-project.policy
```

---

The use case here is allowing third party projects which ship `.policy` files to validate those files using `xmllint`. `xmllint` needs a DTD catalog file in order to look up the DTD from its public ID (`-//freedesktop//DTD polkit Policy Configuration 1.0//EN`). D-Bus does [similar](https://gitlab.freedesktop.org/dbus/dbus/-/blob/main/doc/catalog.xml.in?ref_type=heads).

Subsequent commits move the XML file installation directory to the more standard `/usr/share/xml/polkit-1`, and add a unit test for the policy file shipped by polkit.

Note that this means the installed DTD has moved from `/usr/share/polkit-1/policyconfig-1.dtd` to `/usr/share/xml/polkit-1/policyconfig-1.dtd`. I can add a compatbility symlink from the old location if you wish.

Signed-off-by: Philip Withnall <pwithnall@gnome.org>