### PR TITLE
memory limits in systemd unit to mitigate memory leaks

### DIFF
--- a/data/polkit.service.in
+++ b/data/polkit.service.in
@@ -33,3 +33,9 @@ RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
 UMask=0077
+
+# Mitigate memory leaks
+MemoryMax=32M
+MemorySwapMax=32M
+OOMPolicy=stop
+Restart=on-failure


### PR DESCRIPTION
Over the years there were several reports of polkitd memory leaks consuming gigabytes of RAM. For instance: https://bugs.launchpad.net/ubuntu/+source/policykit-1/+bug/1470235

I am also experiencing a memory leak on my laptop running Ubuntu 24.04:

<img width="499" height="337" alt="image" src="https://github.com/user-attachments/assets/22f07ce6-fed5-4b13-97e3-97b0c5a8bbb3" />

This change limits RAM and swap usage to 32M. Upon reaching this limit, systemd will automatically restart the`polkit.service`.

I tested with more conservative limits: `systemctl set-property --runtime polkit MemoryMax=14M MemorySwapMax=8M`. These limits were acceptable on my system, with peak RAM usage at 8.6M right after restart. Therefore, setting limits to 32M/64M (depending on swap availability) should safely prevent excessive memory usage by polkit.