### PR TITLE
data: Add licensing and copyright data to D-Bus interface XML files

### DIFF
--- a/data/org.freedesktop.PolicyKit1.AuthenticationAgent.xml
+++ b/data/org.freedesktop.PolicyKit1.AuthenticationAgent.xml
@@ -1,3 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2009, 2015 Red Hat
+
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+  Authors:
+   - David Zeuthen <davidz@redhat.com>
+   - Colin Walters <walters@redhat.com>
+   - Miloslav Trmač <mitr@redhat.com>
+-->
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
          "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 

--- a/data/org.freedesktop.PolicyKit1.Authority.xml
+++ b/data/org.freedesktop.PolicyKit1.Authority.xml
@@ -1,3 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2008, 2009, 2015, 2024 Red Hat
+  Copyright 2023, 2024 Luca Boccassi
+
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+  Authors:
+   - David Zeuthen <davidz@redhat.com>
+   - Colin Walters <walters@redhat.com>
+   - Miloslav Trmač <mitr@redhat.com>
+   - Luca Boccassi <luca.boccassi@gmail.com>
+   - Jan Rybar <jrybar@redhat.com>
+-->
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>


### PR DESCRIPTION
These files are likely to be copied into other projects (for example, so proxy objects can be generated from them, or mock interfaces built), so it would be good if their copyright and licensing data went with them.

Copyright data extracted manually by looking at `git log` lists for the two files.
