### PR TITLE
[WIP] No use for authority in polkit_backend_authority_log

### DIFF
--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -1785,12 +1785,11 @@ _color_get (_Color color)
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-G_GNUC_PRINTF(3, 4)
+G_GNUC_PRINTF(2, 3)
 void
-polkit_backend_authority_log (PolkitBackendAuthority *authority,
-                              const guint message_log_level,
-                              const gchar *format,
-                              ...)
+polkit_backend_log (const guint message_log_level,
+                    const gchar *format,
+                    ...)
 {
   guint64 now;
   time_t now_time;
@@ -1803,8 +1802,6 @@ polkit_backend_authority_log (PolkitBackendAuthority *authority,
   {
 	  return;
   }
-
-  g_return_if_fail (POLKIT_BACKEND_IS_AUTHORITY (authority));
 
   va_start (var_args, format);
   message = g_strdup_vprintf (format, var_args);

--- a/src/polkitbackend/polkitbackendauthority.h
+++ b/src/polkitbackend/polkitbackendauthority.h
@@ -226,10 +226,9 @@ const gchar             *polkit_backend_authority_get_name     (PolkitBackendAut
 const gchar             *polkit_backend_authority_get_version  (PolkitBackendAuthority *authority);
 PolkitAuthorityFeatures  polkit_backend_authority_get_features (PolkitBackendAuthority *authority);
 
-void     polkit_backend_authority_log (PolkitBackendAuthority *authority,
-                                       const guint message_log_level,
-                                       const gchar *format,
-                                       ...);
+void     polkit_backend_log (const guint message_log_level,
+                             const gchar *format,
+                             ...);
 
 void
 polkit_backend_authority_set_log_level (const gchar *level);

--- a/src/polkitbackend/polkitbackendcommon.c
+++ b/src/polkitbackend/polkitbackendcommon.c
@@ -349,9 +349,8 @@ polkit_backend_common_on_dir_monitor_changed (GFileMonitor     *monitor,
            event_type == G_FILE_MONITOR_EVENT_DELETED ||
            event_type == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT))
         {
-          polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_INFO,
-                                        "Reloading rules");
+          polkit_backend_log (LOG_LEVEL_INFO,
+                              "Reloading rules");
           polkit_backend_common_reload_scripts (authority);
         }
       g_free (name);

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -695,9 +695,8 @@ log_result (PolkitBackendInteractiveAuthority    *authority,
   if (caller_cmdline == NULL)
     caller_cmdline = g_strdup ("<unknown>");
 
-  polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_INFO,
-                                "%s action %s for %s [%s] owned by %s (check requested by %s [%s])",
+  polkit_backend_log (LOG_LEVEL_INFO,
+                      "%s action %s for %s [%s] owned by %s (check requested by %s [%s])",
                                 log_result_str,
                                 action_id,
                                 subject_str,
@@ -805,10 +804,9 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
     {
       if (is_temp)
         {
-          polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_INFO,
-                                        "Operator of %s successfully authenticated as %s to gain "
-                                        "TEMPORARY authorization for action %s for %s [%s] (owned by %s)",
+          polkit_backend_log (LOG_LEVEL_INFO,
+                              "Operator of %s successfully authenticated as %s to gain "
+                              "TEMPORARY authorization for action %s for %s [%s] (owned by %s)",
                                         scope_str,
                                         authenticated_identity_str,
                                         action_id,
@@ -818,10 +816,9 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
         }
       else
         {
-          polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_INFO,
-                                        "Operator of %s successfully authenticated as %s to gain "
-                                        "ONE-SHOT authorization for action %s for %s [%s] (owned by %s)",
+          polkit_backend_log (LOG_LEVEL_INFO,
+                              "Operator of %s successfully authenticated as %s to gain "
+                              "ONE-SHOT authorization for action %s for %s [%s] (owned by %s)",
                                         scope_str,
                                         authenticated_identity_str,
                                         action_id,
@@ -832,10 +829,9 @@ check_authorization_challenge_cb (AuthenticationAgent         *agent,
     }
   else
     {
-      polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                    LOG_LEVEL_NOTICE,
-                                    "Operator of %s FAILED to authenticate to gain "
-                                    "authorization for action %s for %s [%s] (owned by %s)",
+      polkit_backend_log (LOG_LEVEL_NOTICE,
+                          "Operator of %s FAILED to authenticate to gain "
+                          "authorization for action %s for %s [%s] (owned by %s)",
                                     scope_str,
                                     action_id,
                                     subject_str,
@@ -2104,9 +2100,8 @@ append_property (GString *dest,
     }
   else
     {
-      polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                    LOG_LEVEL_ERROR,
-                                    "Error substituting value for property $(%s) when preparing message `%s' for action-id %s",
+      polkit_backend_log (LOG_LEVEL_ERROR,
+                          "Error substituting value for property $(%s) when preparing message `%s' for action-id %s",
                                     key,
                                     message,
                                     action_id);
@@ -2764,10 +2759,9 @@ polkit_backend_interactive_authority_register_authentication_agent (PolkitBacken
            object_path,
            locale);
 
-  polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_INFO,
-                                "Registered Authentication Agent for %s "
-                                "(system bus name %s [%s], object path %s, locale %s)",
+  polkit_backend_log (LOG_LEVEL_INFO,
+                      "Registered Authentication Agent for %s "
+                      "(system bus name %s [%s], object path %s, locale %s)",
                                 subject_as_string,
                                 polkit_system_bus_name_get_name (POLKIT_SYSTEM_BUS_NAME (caller)),
                                 caller_cmdline,
@@ -2922,10 +2916,9 @@ polkit_backend_interactive_authority_unregister_authentication_agent (PolkitBack
            agent->object_path,
            agent->locale);
 
-  polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_INFO,
-                                "Unregistered Authentication Agent for %s "
-                                "(system bus name %s, object path %s, locale %s)",
+  polkit_backend_log (LOG_LEVEL_INFO,
+                      "Unregistered Authentication Agent for %s "
+                      "(system bus name %s, object path %s, locale %s)",
                                 scope_str,
                                 agent->unique_system_bus_name,
                                 agent->object_path,
@@ -3075,10 +3068,9 @@ polkit_backend_interactive_authority_system_bus_name_owner_changed (PolkitBacken
                    agent->unique_system_bus_name,
                    agent->object_path);
 
-          polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                        LOG_LEVEL_INFO,
-                                        "Unregistered Authentication Agent for %s "
-                                        "(system bus name %s, object path %s, locale %s) (disconnected from bus)",
+          polkit_backend_log (LOG_LEVEL_INFO,
+                              "Unregistered Authentication Agent for %s "
+                              "(system bus name %s, object path %s, locale %s) (disconnected from bus)",
                                         scope_str,
                                         agent->unique_system_bus_name,
                                         agent->object_path,

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -174,9 +174,8 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
-  polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_WARNING,
-                                "Lost the name org.freedesktop.PolicyKit1 - exiting");
+  polkit_backend_log (LOG_LEVEL_WARNING,
+                      "Lost the name org.freedesktop.PolicyKit1 - exiting");
   g_main_loop_quit (loop);
 }
 
@@ -187,9 +186,8 @@ on_name_acquired (GDBusConnection *connection,
 {
   exit_status = EXIT_SUCCESS;
 
-  polkit_backend_authority_log (POLKIT_BACKEND_AUTHORITY (authority),
-                                LOG_LEVEL_INFO,
-                                "Acquired the name org.freedesktop.PolicyKit1 on the system bus");
+  polkit_backend_log (LOG_LEVEL_INFO,
+                      "Acquired the name org.freedesktop.PolicyKit1 on the system bus");
 }
 
 static gboolean


### PR DESCRIPTION
The authority argument is actually only used for verifying it's really a polkit authority and nothing else. This limits the usage of the function only to parts of the *backend* where authority is passed and nowhere else. This leads to the need to use g_print or g_error fns to be used where *authority doesn't exist. Logs passed to glib sometimes do not reach journal and do not conform to loglevels.

## Summary
[short description of the problem and the change]: #



## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
Fixes #518 
