### PR TITLE
agent helper: Send standard error to journal

### DIFF
--- a/data/polkit-agent-helper@.service.in
+++ b/data/polkit-agent-helper@.service.in
@@ -10,6 +10,7 @@ ExecStart=@libprivdir@/polkit-agent-helper-1 --socket-activated
 SuccessExitStatus=2
 StandardInput=socket
 StandardOutput=socket
+StandardError=journal
 LimitMEMLOCK=0
 LockPersonality=yes
 MemoryDenyWriteExecute=yes


### PR DESCRIPTION
Otherwise we will most likely get the default of `StandardError=inherit`, causing any log messages to be sent to the peer, which gets confused and fails the authentication session.

See: https://github.com/polkit-org/polkit/issues/622
See: https://gitlab.archlinux.org/archlinux/packaging/packages/polkit/-/issues/4
