### PR TITLE
agent helper: relax device access for hardware based authentication

### DIFF
--- a/data/polkit-agent-helper@.service.in
+++ b/data/polkit-agent-helper@.service.in
@@ -4,7 +4,7 @@ Documentation=man:polkit(8)
 
 [Service]
 Type=oneshot
-DevicePolicy=closed
+DevicePolicy=auto
 ExecStart=@libprivdir@/polkit-agent-helper-1 --socket-activated
 SuccessExitStatus=2
 StandardInput=socket
@@ -14,7 +14,7 @@ LimitMEMLOCK=0
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
-PrivateDevices=yes
+PrivateDevices=no
 PrivateNetwork=yes
 PrivateTmp=yes
 ProtectControlGroups=yes


### PR DESCRIPTION
Various pam modules may use physical hardware like tokens, cameras, fingerprint readers
for authentication thus they need unconstrained /dev access.

They aren't enabled by default in distros pam stack for obvious reasons but their existence
shouldn't be ignored and supported authentication methods limited to plain password.

Fixes https://github.com/polkit-org/polkit/issues/622

Fixes https://github.com/polkit-org/polkit/issues/623