### PR TITLE
polkit-agent-helper service: simplify sandbox rules for /dev

### DIFF
--- a/data/polkit-agent-helper@.service.in
+++ b/data/polkit-agent-helper@.service.in
@@ -4,8 +4,7 @@ Documentation=man:polkit(8)
 
 [Service]
 Type=oneshot
-DeviceAllow=/dev/null rw
-DevicePolicy=strict
+DevicePolicy=closed
 ExecStart=@libprivdir@/polkit-agent-helper-1 --socket-activated
 SuccessExitStatus=2
 StandardInput=socket


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #

Using 'DevicePolicy=strict' blocks even limited device access set by 'PrivateDevices=yes' which overcomplicates the setup. The latter alone should be sufficient for effective sandboxing.

This was proposed in https://github.com/polkit-org/polkit/pull/626#discussion_r2640544693 cc: @bluca 

## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
