### PR TITLE
test: do not fail if unshare returns EINVAL

### DIFF
--- a/test/wrapper.py
+++ b/test/wrapper.py
@@ -38,6 +38,11 @@ def setup_test_namespace(data_dir):
     except AttributeError:
         print("Python 3.12 is required for os.unshare(), skipping")
         sys.exit(77)
+    except OSError as e:
+        if e.errno == errno.EINVAL:
+            print("os.unshare(os.CLONE_NEWNS|os.CLONE_NEWUSER) not supported, skipping")
+            sys.exit(77)
+        raise
 
 
 def stop_dbus(pid: int) -> None:


### PR DESCRIPTION
On some niche architectures unshare() does not work at all and returns EINVAL, do not fail the test, as the test's purpose is not to test unshare().

On HPPA:

```
1/5 polkit:polkitunixusertest            FAIL            3.60s   exit status 1
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
stdout:
Test data dir: /<<PKGBUILDDIR>>/test/data
stderr:
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/test/wrapper.py", line 82, in <module>
    setup_test_namespace(args.data_dir)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/<<PKGBUILDDIR>>/test/wrapper.py", line 24, in setup_test_namespace
    os.unshare(os.CLONE_NEWNS|os.CLONE_NEWUSER)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 22] Invalid argument
```

https://buildd.debian.org/status/fetch.php?pkg=policykit-1&arch=hppa&ver=127-2&stamp=1770659670&raw=0

Follow-up for 8e17f09c770bc2efd5deb40ba2b6032d40603578