### PR TITLE
fix race in deleting agent after unregistering bus

### DIFF
--- a/src/polkit/polkitsubject.c
+++ b/src/polkit/polkitsubject.c
@@ -540,3 +540,10 @@ polkit_subject_new_for_gvariant (GVariant  *variant,
 {
   return polkit_subject_new_for_gvariant_invocation (variant, NULL, error);
 }
+
+gboolean
+polkit_subject_state_check (PolkitSubject *subject)
+{
+  g_return_val_if_fail (POLKIT_IS_SUBJECT (subject), 0);
+  return POLKIT_SUBJECT_GET_IFACE (subject)->check (subject);
+}

--- a/src/polkit/polkitsubject.h
+++ b/src/polkit/polkitsubject.h
@@ -83,6 +83,8 @@ struct _PolkitSubjectIface
   gboolean (*exists_sync)   (PolkitSubject       *subject,
                              GCancellable        *cancellable,
                              GError             **error);
+
+  gboolean (*check)         (PolkitSubject       *subject);
 };
 
 GType          polkit_subject_get_type      (void) G_GNUC_CONST;
@@ -102,6 +104,7 @@ gboolean       polkit_subject_exists_finish (PolkitSubject       *subject,
 gboolean       polkit_subject_exists_sync   (PolkitSubject       *subject,
                                              GCancellable        *cancellable,
                                              GError             **error);
+gboolean       polkit_subject_state_check   (PolkitSubject       *subject);
 
 G_END_DECLS
 

--- a/src/polkit/polkitsystembusname.c
+++ b/src/polkit/polkitsystembusname.c
@@ -271,6 +271,12 @@ polkit_system_bus_name_exists_sync (PolkitSubject   *subject,
   return ret;
 }
 
+static gboolean
+polkit_system_bus_name_check (PolkitSubject   *subject)
+{
+  return TRUE;
+}
+
 static void
 exists_in_thread_func (GSimpleAsyncResult *res,
                        GObject            *object,
@@ -338,6 +344,7 @@ subject_iface_init (PolkitSubjectIface *subject_iface)
   subject_iface->exists        = polkit_system_bus_name_exists;
   subject_iface->exists_finish = polkit_system_bus_name_exists_finish;
   subject_iface->exists_sync   = polkit_system_bus_name_exists_sync;
+  subject_iface->check         = polkit_system_bus_name_check;
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/polkit/polkitunixprocess.c
+++ b/src/polkit/polkitunixprocess.c
@@ -390,7 +390,6 @@ polkit_unix_process_constructed (GObject *object)
       if (pidfd >= 0)
         {
           process->pidfd = pidfd;
-          process->pid = 0;
         }
     }
 
@@ -1060,8 +1059,9 @@ static guint
 polkit_unix_process_hash (PolkitSubject *subject)
 {
   PolkitUnixProcess *process = POLKIT_UNIX_PROCESS (subject);
+  guint hash_value = process->pid + process->start_time;
 
-  return g_direct_hash (GSIZE_TO_POINTER ((polkit_unix_process_get_pid(process) + process->start_time))) ;
+  return g_direct_hash (GSIZE_TO_POINTER (hash_value)) ;
 }
 
 static gboolean
@@ -1076,8 +1076,8 @@ polkit_unix_process_equal (PolkitSubject *a,
   process_a = POLKIT_UNIX_PROCESS (a);
   process_b = POLKIT_UNIX_PROCESS (b);
 
-  pid_a = polkit_unix_process_get_pid(process_a);
-  pid_b = polkit_unix_process_get_pid(process_b);
+  pid_a = process_a->pid;
+  pid_b = process_b->pid;
 
   pidfd_a = polkit_unix_process_get_pidfd(process_a);
   pidfd_b = polkit_unix_process_get_pidfd(process_b);
@@ -1142,6 +1142,14 @@ polkit_unix_process_exists_sync (PolkitSubject   *subject,
   return ret;
 }
 
+static gboolean
+polkit_unix_process_check (PolkitSubject *subject)
+{
+  PolkitUnixProcess *process = POLKIT_UNIX_PROCESS (subject);
+  gint pid = polkit_unix_process_get_pid(process);
+  return (pid > 0 && pid == process->pid);
+}
+
 static void
 polkit_unix_process_exists (PolkitSubject       *subject,
                             GCancellable        *cancellable,
@@ -1181,6 +1189,7 @@ subject_iface_init (PolkitSubjectIface *subject_iface)
   subject_iface->exists        = polkit_unix_process_exists;
   subject_iface->exists_finish = polkit_unix_process_exists_finish;
   subject_iface->exists_sync   = polkit_unix_process_exists_sync;
+  subject_iface->check         = polkit_unix_process_check;
 }
 
 #ifdef HAVE_SOLARIS

--- a/src/polkit/polkitunixsession-systemd.c
+++ b/src/polkit/polkitunixsession-systemd.c
@@ -370,6 +370,12 @@ polkit_unix_session_exists_sync (PolkitSubject   *subject,
   return ret;
 }
 
+static gboolean
+polkit_unix_session_check (PolkitSubject   *subject)
+{
+  return TRUE;
+}
+
 static void
 exists_in_thread_func (GSimpleAsyncResult *res,
                        GObject            *object,
@@ -437,6 +443,7 @@ subject_iface_init (PolkitSubjectIface *subject_iface)
   subject_iface->exists        = polkit_unix_session_exists;
   subject_iface->exists_finish = polkit_unix_session_exists_finish;
   subject_iface->exists_sync   = polkit_unix_session_exists_sync;
+  subject_iface->check         = polkit_unix_session_check;
 }
 
 static gboolean

--- a/src/polkit/polkitunixsession.c
+++ b/src/polkit/polkitunixsession.c
@@ -391,6 +391,12 @@ polkit_unix_session_exists_sync (PolkitSubject   *subject,
   return ret;
 }
 
+static gboolean
+polkit_unix_session_check (PolkitSubject   *subject)
+{
+  return TRUE;
+}
+
 static void
 exists_in_thread_func (GSimpleAsyncResult *res,
                        GObject            *object,
@@ -458,6 +464,7 @@ subject_iface_init (PolkitSubjectIface *subject_iface)
   subject_iface->exists        = polkit_unix_session_exists;
   subject_iface->exists_finish = polkit_unix_session_exists_finish;
   subject_iface->exists_sync   = polkit_unix_session_exists_sync;
+  subject_iface->check         = polkit_unix_session_check;
 }
 
 static gboolean

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -97,6 +97,8 @@ typedef void (*AuthenticationAgentCallback) (AuthenticationAgent         *agent,
 
 static AuthenticationAgent *authentication_agent_ref   (AuthenticationAgent *agent);
 static void                 authentication_agent_unref (AuthenticationAgent *agent);
+static void                 check_agent_subject        (AuthenticationAgent *agent, 
+                                                        PolkitSubject *subject);
 
 static void                authentication_agent_initiate_challenge (AuthenticationAgent         *agent,
                                                                     PolkitSubject               *subject,
@@ -1785,6 +1787,16 @@ authentication_agent_unref (AuthenticationAgent *agent)
     }
 }
 
+static void
+check_agent_subject (AuthenticationAgent *agent, PolkitSubject *subject)
+{
+  gboolean is_subject_correct = polkit_subject_state_check(subject);
+  if (is_subject_correct == FALSE)
+  {
+    agent = NULL;
+  }
+}
+
 static AuthenticationAgent *
 authentication_agent_new (guint64      serial,
                           PolkitSubject *scope,
@@ -1871,6 +1883,8 @@ get_authentication_agent_for_subject (PolkitBackendInteractiveAuthority *authori
 
   agent = g_hash_table_lookup (priv->hash_scope_to_authentication_agent, subject);
 
+  check_agent_subject (agent, subject);
+
   if (agent == NULL && POLKIT_IS_SYSTEM_BUS_NAME (subject))
     {
       PolkitSubject *process;
@@ -1915,6 +1929,8 @@ get_authentication_agent_for_subject (PolkitBackendInteractiveAuthority *authori
 
   agent = g_hash_table_lookup (priv->hash_scope_to_authentication_agent, session_for_subject);
 
+  check_agent_subject (agent, subject);
+
   /* use fallback, if available */
   if (agent == NULL && agent_fallback != NULL)
     agent = agent_fallback;
@@ -1934,6 +1950,7 @@ get_authentication_session_for_uid_and_cookie (PolkitBackendInteractiveAuthority
   PolkitBackendInteractiveAuthorityPrivate *priv;
   GHashTableIter hash_iter;
   AuthenticationAgent *agent;
+  PolkitSubject *subject;
   AuthenticationSession *result;
 
   result = NULL;
@@ -1943,7 +1960,7 @@ get_authentication_session_for_uid_and_cookie (PolkitBackendInteractiveAuthority
   priv = polkit_backend_interactive_authority_get_instance_private (authority);
 
   g_hash_table_iter_init (&hash_iter, priv->hash_scope_to_authentication_agent);
-  while (g_hash_table_iter_next (&hash_iter, NULL, (gpointer) &agent))
+  while (g_hash_table_iter_next (&hash_iter, (gpointer) &subject, (gpointer) &agent))
     {
       GList *l;
 
@@ -1958,6 +1975,9 @@ get_authentication_session_for_uid_and_cookie (PolkitBackendInteractiveAuthority
        * who is using our own setuid helper will automatically be updated
        * to the new API.
        */
+      
+      check_agent_subject(agent, subject);
+      
       if (uid != (uid_t)-1)
         {
           if (agent->creator_uid != uid)
@@ -1986,6 +2006,7 @@ get_authentication_sessions_initiated_by_system_bus_unique_name (PolkitBackendIn
 {
   PolkitBackendInteractiveAuthorityPrivate *priv;
   GHashTableIter hash_iter;
+  PolkitSubject *subject;
   AuthenticationAgent *agent;
   GList *result;
 
@@ -1996,9 +2017,11 @@ get_authentication_sessions_initiated_by_system_bus_unique_name (PolkitBackendIn
   priv = polkit_backend_interactive_authority_get_instance_private (authority);
 
   g_hash_table_iter_init (&hash_iter, priv->hash_scope_to_authentication_agent);
-  while (g_hash_table_iter_next (&hash_iter, NULL, (gpointer) &agent))
+  while (g_hash_table_iter_next (&hash_iter, (gpointer) &subject, (gpointer) &agent))
     {
       GList *l;
+
+      check_agent_subject(agent, subject);
 
       for (l = agent->active_sessions; l != NULL; l = l->next)
         {
@@ -2763,6 +2786,7 @@ polkit_backend_interactive_authority_register_authentication_agent (PolkitBacken
     }
 
   agent = g_hash_table_lookup (priv->hash_scope_to_authentication_agent, subject);
+  check_agent_subject (agent, subject);
   if (agent != NULL)
     {
       g_set_error (error,
@@ -3123,14 +3147,14 @@ polkit_backend_interactive_authority_system_bus_name_owner_changed (PolkitBacken
 
       agent = get_authentication_agent_by_unique_system_bus_name (interactive_authority, name);
       if (agent != NULL)
-        {
+      {
           gchar *scope_str;
-
+          
           scope_str = polkit_subject_to_string (agent->scope);
           g_debug ("Removing authentication agent for %s at name %s, object path %s (disconnected from bus)",
-                   scope_str,
-                   agent->unique_system_bus_name,
-                   agent->object_path);
+            scope_str,
+            agent->unique_system_bus_name,
+            agent->object_path);
 
           {
             gchar *locale_safe = sanitize_for_log (agent->locale);


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
Fix race in deleting agent after unregistering bus
Sometimes function that get agent is slower than operating system and pidfd is deleted faster that it can use it to find right agent in hash map.

## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
Make function calculating hash for subject stable so agent can be deleted after process exited. Add agent correctness function that check if subject pid doesn't change. Use subject initial pid in functions for checking equal and calculating hash.

Can be reproduced by printing all Gobjects in loop in polkitd and using : 
`while true; do   for i in $(seq 1 10000); do loginctl enable-linger $USER; sleep 0.1; done; echo; done`
If loop run for more than few hours memory usage increase can be also seen in top command

Related to #150 