### PR TITLE
Revert "memory limits in systemd unit to mitigate memory leaks"

### DIFF
--- a/data/polkit.service.in
+++ b/data/polkit.service.in
@@ -33,9 +33,3 @@ RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
 UMask=0077
-
-# Mitigate memory leaks
-MemoryMax=32M
-MemorySwapMax=32M
-OOMPolicy=stop
-Restart=on-failure


### PR DESCRIPTION
This causes breakages when running with system-wide sanitizers, and it's a poor band-aid anyway. If there are any memory leaks, they need to be found with profiling and fixed.

This reverts commit 7d9c06c58a957ee3f2a4383ade6f207b05207e3e.