### PR TITLE
tree-wide: don't leak the GError object on error

### DIFF
--- a/src/polkitbackend/polkitbackendactionpool.c
+++ b/src/polkitbackend/polkitbackendactionpool.c
@@ -544,6 +544,7 @@ ensure_file (PolkitBackendActionPool *pool,
   basename = NULL;
 
  out:
+  g_clear_error (&error);
   g_free (basename);
   g_free (path);
 }

--- a/src/polkitbackend/polkitbackendactionpool.c
+++ b/src/polkitbackend/polkitbackendactionpool.c
@@ -586,7 +586,7 @@ ensure_all_files (PolkitBackendActionPool *pool)
     else
     {
       GFileInfo *file_info;
-      while ((file_info = g_file_enumerator_next_file (enumerator, NULL, &error)) != NULL)
+      while ((file_info = g_file_enumerator_next_file (enumerator, NULL, NULL)) != NULL)
       {
         const gchar *name = g_file_info_get_name (file_info);
         /* only consider files with the right suffix */

--- a/src/programs/pkcheck.c
+++ b/src/programs/pkcheck.c
@@ -555,10 +555,12 @@ main (int argc, char *argv[])
                                                       &error);
   if (result == NULL)
     {
+      g_assert(error != NULL);
       g_printerr ("Error checking for authorization %s: %s\n",
                   action_id,
-                  error ? error->message : "Could not verify; error object not present.");
+                  error->message);
       ret = 127;
+      g_error_free (error);
       goto out;
     }
 

--- a/src/programs/pkcheck.c
+++ b/src/programs/pkcheck.c
@@ -526,6 +526,11 @@ main (int argc, char *argv[])
       g_printerr (_("%s: Subject not specified\n"), g_get_prgname ());
       goto out;
     }
+  else if (action_id == NULL)
+    {
+      g_printerr (_("%s: Action ID not specified\n"), g_get_prgname ());
+      goto out;
+    }
 
   error = NULL;
   authority = polkit_authority_get_sync (NULL /* GCancellable* */, &error);

--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -252,9 +252,8 @@ fdwalk_close_on_exec (guint fd_bottom)
 #ifdef __linux__
   GDir *dir;
   const gchar *file;
-  GError *error;
 
-  dir = g_dir_open ("/proc/self/fd/", 0, &error);
+  dir = g_dir_open ("/proc/self/fd/", 0, NULL);
   if (dir != NULL)
     {
       while ((file = g_dir_read_name (dir)) != NULL)

--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -910,9 +910,11 @@ main (int argc, char *argv[])
                                                       &error);
   if (result == NULL)
     {
+      g_assert(error != NULL);
       g_printerr ("Error checking for authorization %s: %s\n",
                   action_id,
-		  error ? error->message : "Could not verify; error object not present.");
+                  error->message);
+      g_error_free (error);
       goto out;
     }
 


### PR DESCRIPTION
While debugging #653 I noticed one other possible leak, and after taking a deeper dive I found a bunch more.

See the commit descriptions for more information & justification of each change.