### PR TITLE
Avoid periodic polling for non-existent polkit rules directories

### DIFF
--- a/docs/man/polkitd.xml
+++ b/docs/man/polkitd.xml
@@ -69,7 +69,7 @@
           <para>
             If set, overrides the default directories used to load JavaScript
             authorization rules. The value is a colon-separated list of
-            directories.
+            directories. Empty path elements are ignored.
           </para>
         </listitem>
       </varlistentry>

--- a/docs/man/polkitd.xml
+++ b/docs/man/polkitd.xml
@@ -61,6 +61,21 @@
     </para>
   </refsect1>
 
+  <refsect1 id="polkitd-environment"><title>ENVIRONMENT</title>
+    <variablelist>
+      <varlistentry>
+        <term><envar>POLKIT_RULES_DIRS</envar></term>
+        <listitem>
+          <para>
+            If set, overrides the default directories used to load JavaScript
+            authorization rules. The value is a colon-separated list of
+            directories.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
   <refsect1 id="polkitd-author"><title>AUTHOR</title>
     <para>
       Written by David Zeuthen <email>davidz@redhat.com</email> with

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -30,6 +30,8 @@
 /* Built source and not too big to worry about deduplication */
 #include "initjs.h" /* init.js */
 
+#define POLKIT_RULES_DIRS_ENV_VAR "POLKIT_RULES_DIRS"
+
 /**
  * SECTION:polkitbackendjsauthority
  * @title: PolkitBackendJsAuthority
@@ -95,6 +97,39 @@ static void
 polkit_backend_js_authority_init (PolkitBackendJsAuthority *authority)
 {
   authority->priv = polkit_backend_js_authority_get_instance_private (authority);
+}
+
+static gchar **
+rules_dirs_from_environment (void)
+{
+  const gchar *rules_dirs;
+  gchar **split_rules_dirs;
+  GPtrArray *ret;
+  guint n;
+
+  rules_dirs = g_getenv (POLKIT_RULES_DIRS_ENV_VAR);
+  if (rules_dirs == NULL || rules_dirs[0] == '\0')
+    return NULL;
+
+  split_rules_dirs = g_strsplit (rules_dirs, G_SEARCHPATH_SEPARATOR_S, -1);
+  ret = g_ptr_array_new ();
+
+  for (n = 0; split_rules_dirs != NULL && split_rules_dirs[n] != NULL; n++)
+    {
+      if (split_rules_dirs[n][0] != '\0')
+        g_ptr_array_add (ret, g_strdup (split_rules_dirs[n]));
+    }
+
+  g_strfreev (split_rules_dirs);
+
+  if (ret->len == 0)
+    {
+      g_ptr_array_free (ret, TRUE);
+      return NULL;
+    }
+
+  g_ptr_array_add (ret, NULL);
+  return (gchar **) g_ptr_array_free (ret, FALSE);
 }
 
 static void
@@ -253,13 +288,17 @@ polkit_backend_common_js_authority_constructed (GObject *object)
 
   if (authority->priv->rules_dirs == NULL)
     {
-      authority->priv->rules_dirs = g_new0 (gchar *, 5);
-      authority->priv->rules_dirs[0] = g_strdup (PACKAGE_SYSCONF_DIR "/polkit-1/rules.d");
-      authority->priv->rules_dirs[1] = g_strdup ("/run/polkit-1/rules.d");
-      authority->priv->rules_dirs[2] = g_strdup ("/usr/local/share/polkit-1/rules.d");
-      if (g_strcmp0 (PACKAGE_DATA_DIR, "/usr/local/share") != 0)
+      authority->priv->rules_dirs = rules_dirs_from_environment ();
+      if (authority->priv->rules_dirs == NULL)
         {
-          authority->priv->rules_dirs[3] = g_strdup (PACKAGE_DATA_DIR "/polkit-1/rules.d");
+          authority->priv->rules_dirs = g_new0 (gchar *, 5);
+          authority->priv->rules_dirs[0] = g_strdup (PACKAGE_SYSCONF_DIR "/polkit-1/rules.d");
+          authority->priv->rules_dirs[1] = g_strdup ("/run/polkit-1/rules.d");
+          authority->priv->rules_dirs[2] = g_strdup ("/usr/local/share/polkit-1/rules.d");
+          if (g_strcmp0 (PACKAGE_DATA_DIR, "/usr/local/share") != 0)
+            {
+              authority->priv->rules_dirs[3] = g_strdup (PACKAGE_DATA_DIR "/polkit-1/rules.d");
+            }
         }
     }
 

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -102,34 +102,31 @@ polkit_backend_js_authority_init (PolkitBackendJsAuthority *authority)
 static gchar **
 rules_dirs_from_environment (void)
 {
-  const gchar *rules_dirs;
+  const gchar *rules_dirs_env;
   gchar **split_rules_dirs;
-  GPtrArray *ret;
-  guint n;
+  guint read_index, write_index;
 
-  rules_dirs = g_getenv (POLKIT_RULES_DIRS_ENV_VAR);
-  if (rules_dirs == NULL || rules_dirs[0] == '\0')
+  rules_dirs_env = g_getenv (POLKIT_RULES_DIRS_ENV_VAR);
+  if (rules_dirs_env == NULL || rules_dirs_env[0] == '\0')
     return NULL;
 
-  split_rules_dirs = g_strsplit (rules_dirs, G_SEARCHPATH_SEPARATOR_S, -1);
-  ret = g_ptr_array_new ();
-
-  for (n = 0; split_rules_dirs != NULL && split_rules_dirs[n] != NULL; n++)
+  split_rules_dirs = g_strsplit (rules_dirs_env, G_SEARCHPATH_SEPARATOR_S, -1);
+  for (read_index = 0, write_index = 0; split_rules_dirs[read_index] != NULL; read_index++)
     {
-      if (split_rules_dirs[n][0] != '\0')
-        g_ptr_array_add (ret, g_strdup (split_rules_dirs[n]));
+      if (split_rules_dirs[read_index][0] == '\0')
+        g_free (split_rules_dirs[read_index]);
+      else
+        split_rules_dirs[write_index++] = split_rules_dirs[read_index];
     }
+  split_rules_dirs[write_index] = NULL;
 
-  g_strfreev (split_rules_dirs);
-
-  if (ret->len == 0)
+  if (write_index == 0)
     {
-      g_ptr_array_free (ret, TRUE);
+      g_strfreev (split_rules_dirs);
       return NULL;
     }
 
-  g_ptr_array_add (ret, NULL);
-  return (gchar **) g_ptr_array_free (ret, FALSE);
+  return split_rules_dirs;
 }
 
 static void

--- a/test/polkitbackend/test-polkitbackendjsauthority.c
+++ b/test/polkitbackend/test-polkitbackendjsauthority.c
@@ -22,6 +22,7 @@
  */
 
 #include "glib.h"
+#include <glib/gstdio.h>
 
 #include <locale.h>
 #include <string.h>
@@ -152,6 +153,78 @@ test_get_admin_identities (void)
       test_get_admin_identities_for_action_id (test_cases[n].action_id,
                                                test_cases[n].expected_admins);
     }
+}
+
+static void
+test_rules_dirs_from_environment (void)
+{
+  PolkitBackendJsAuthority *authority = NULL;
+  PolkitSubject *caller = NULL;
+  PolkitSubject *subject = NULL;
+  PolkitIdentity *user_for_subject = NULL;
+  PolkitDetails *details = NULL;
+  GError *error = NULL;
+  PolkitImplicitAuthorization result;
+  gchar *rules_dir = NULL;
+  gchar *rules_file = NULL;
+  gchar *rules_dirs_env = NULL;
+  gchar *old_rules_dirs_env = NULL;
+  const gchar *rules =
+    "polkit.addRule(function(action, subject) {\n"
+    "    if (action.id == \"net.company.env_rules_dirs\") {\n"
+    "        return polkit.Result.YES;\n"
+    "    }\n"
+    "});\n";
+
+  rules_dir = g_dir_make_tmp ("polkit-rules-dir-XXXXXX", &error);
+  g_assert_no_error (error);
+  g_assert (rules_dir != NULL);
+
+  rules_file = g_build_filename (rules_dir, "10-environment.rules", NULL);
+  g_file_set_contents (rules_file, rules, -1, &error);
+  g_assert_no_error (error);
+
+  old_rules_dirs_env = g_strdup (g_getenv ("POLKIT_RULES_DIRS"));
+  rules_dirs_env = g_strdup (rules_dir);
+  g_setenv ("POLKIT_RULES_DIRS", rules_dirs_env, TRUE);
+
+  authority = g_object_new (POLKIT_BACKEND_TYPE_JS_AUTHORITY, NULL);
+
+  if (old_rules_dirs_env != NULL)
+    g_setenv ("POLKIT_RULES_DIRS", old_rules_dirs_env, TRUE);
+  else
+    g_unsetenv ("POLKIT_RULES_DIRS");
+
+  caller = polkit_unix_process_new_for_owner (getpid (), 0, getuid ());
+  subject = polkit_unix_process_new_for_owner (getpid (), 0, getuid ());
+  user_for_subject = polkit_identity_from_string ("unix-user:root", &error);
+  g_assert_no_error (error);
+
+  details = polkit_details_new ();
+
+  result = polkit_backend_interactive_authority_check_authorization_sync (POLKIT_BACKEND_INTERACTIVE_AUTHORITY (authority),
+                                                                          caller,
+                                                                          subject,
+                                                                          user_for_subject,
+                                                                          TRUE,
+                                                                          TRUE,
+                                                                          "net.company.env_rules_dirs",
+                                                                          details,
+                                                                          POLKIT_IMPLICIT_AUTHORIZATION_UNKNOWN);
+  g_assert_cmpint (result, ==, POLKIT_IMPLICIT_AUTHORIZATION_AUTHORIZED);
+
+  g_clear_object (&details);
+  g_clear_object (&user_for_subject);
+  g_clear_object (&subject);
+  g_clear_object (&caller);
+  g_clear_object (&authority);
+
+  g_remove (rules_file);
+  g_rmdir (rules_dir);
+  g_free (old_rules_dirs_env);
+  g_free (rules_dirs_env);
+  g_free (rules_file);
+  g_free (rules_dir);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
@@ -508,6 +581,7 @@ main (int argc, char *argv[])
   //polkit_test_redirect_logs ();
 
   g_test_add_func ("/PolkitBackendJsAuthority/get_admin_identities", test_get_admin_identities);
+  g_test_add_func ("/PolkitBackendJsAuthority/rules_dirs_from_environment", test_rules_dirs_from_environment);
   add_rules_tests ();
 
   return g_test_run ();

--- a/test/polkitbackend/test-polkitbackendjsauthority.c
+++ b/test/polkitbackend/test-polkitbackendjsauthority.c
@@ -185,7 +185,7 @@ test_rules_dirs_from_environment (void)
   g_assert_no_error (error);
 
   old_rules_dirs_env = g_strdup (g_getenv ("POLKIT_RULES_DIRS"));
-  rules_dirs_env = g_strdup (rules_dir);
+  rules_dirs_env = g_strjoin (G_SEARCHPATH_SEPARATOR_S, "", rules_dir, "", NULL);
   g_setenv ("POLKIT_RULES_DIRS", rules_dirs_env, TRUE);
 
   authority = g_object_new (POLKIT_BACKEND_TYPE_JS_AUTHORITY, NULL);


### PR DESCRIPTION
## Summary

Currently, `polkitbackendduktapeauthority.c` watches a set of hardcoded rule directories. If some of these directories do not exist, GLib’s inotify backend falls back to polling: every 4 seconds it attempts to add the inotify watch again.

This can result in repeated filesystem lookups for paths that are known to be unused on a given system. I noticed this while experimenting with eBPF and tracing `__lookup_slow`:

```bash
sudo bpftrace -e 'kprobe:__lookup_slow { printf("Name: %s, Parent: %p, Flags: %d\n", str(((struct qstr *)arg0)->name), arg1, arg2); }'
```

On systems where polkit rules are stored only in specific locations (and we are a 100% sure the user can't add more rules, since they're declared and immutable, like for example NixOS + impermanence setup), repeatedly checking missing directories is unnecessary. Even if the underlying filesystem is usually something lightweight like `tmpfs`, avoiding this polling is still preferable when we already know that certain rule directories will never be used.

This PR introduces an optional environment variable, empty by default, that allows users or distributions to explicitly specify the directories where polkit should look for rules. When set, `polkitd` will use those directories instead of watching all the hardcoded rule paths. This allows systems with known rule locations to avoid the repeated polling caused by missing directories.

The polling behavior comes from GLib's inotify fallback implementation. When `inotify_add_watch()` fails, GLib adds the path to a "missing" watch list and periodically retries the watch every 4 seconds by default, some of the interesting links of the glib source code are the following:

- [(glib) set ups a callback for executing `im_scan_missing` each SCAN_MISSING_TIME (4 secs by default)](https://github.com/GNOME/glib/blob/main/gio/inotify/inotify-missing.c#L60)
- [(glib) `im_scan_missing`, tries to inotify the dirs, if it fails because they don't exist, don't remove the callback](https://github.com/GNOME/glib/blob/main/gio/inotify/inotify-missing.c#L108)


This PR may also be related to issue #90, although that issue mentions both configuration and rules directories, while this change only affects rule directories.

I am opening this as a draft because I have not yet checked whether there has already been previous discussion or an existing proposal around this idea, or whether the project would consider this approach viable.

I am also still pretty new to this codebase (first time with gnome glib...), and I used some AI assistance to help me get familiar with it, so please feel free to be strict in the review. :)


## Detailed description and/or reproducer
You can reproduce the "issue" (if it can be considered an issue?) via the eBPF command that I told you in the summary section. Be aware that, if you have all the "hardcoded" folders created, you may have to delete one of them to see the polling behavior. 