### PR TITLE
polkitbackend: fix synthetic-caller leak and NULL unref in push_subject

### DIFF
--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -544,7 +544,7 @@ else
   ret = TRUE;
 
  out:
-  if (POLKIT_IS_SYSTEM_BUS_NAME (subject))
+  if (POLKIT_IS_SYSTEM_BUS_NAME (subject) && process != NULL)
     g_object_unref (process);
   free (session_str);
   free (seat_str);

--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -1008,6 +1008,7 @@ polkit_backend_interactive_authority_check_authorization (PolkitBackendAuthority
 {
   PolkitBackendInteractiveAuthority *interactive_authority;
   PolkitBackendInteractiveAuthorityPrivate *priv;
+  PolkitSubject *local_caller = NULL;
   gchar *caller_str;
   gchar *subject_str;
   PolkitIdentity *user_of_caller;
@@ -1045,7 +1046,8 @@ polkit_backend_interactive_authority_check_authorization (PolkitBackendAuthority
       /* TODO: this is kind of a hack */
       GDBusConnection *system_bus;
       system_bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);
-      caller = polkit_system_bus_name_new (g_dbus_connection_get_unique_name (system_bus));
+      local_caller = polkit_system_bus_name_new (g_dbus_connection_get_unique_name (system_bus));
+      caller = local_caller;
       g_object_unref (system_bus);
     }
 
@@ -1216,6 +1218,9 @@ polkit_backend_interactive_authority_check_authorization (PolkitBackendAuthority
 
   if (result != NULL)
     g_object_unref (result);
+
+  if (local_caller != NULL)
+    g_object_unref (local_caller);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Two small memory-management fixes for `polkitd`, uncovered while auditing the per-`CheckAuthorization` hot path. Combined diff: 7 insertions, 2 deletions across 2 files. Both bugs are pre-existing — not regressions from the recent leak fixes (#640 / #653 / #654 / #571 / #576 / #563).

1. **`polkit_backend_interactive_authority_check_authorization()`** leaks one `PolkitSystemBusName` per self-invocation (calls where `caller == NULL`). The "called from ourselves" branch allocates a fresh caller via `polkit_system_bus_name_new()` and never unrefs it.
2. **`push_subject()`** calls `g_object_unref(NULL)` when `polkit_system_bus_name_get_process_sync()` fails (bus name vanishes mid-query), producing a `GLib-GObject-CRITICAL` warning in the journal. Not a leak per se, but matches the cleanup style of the recently-merged GError fixes.

## Detailed description and/or reproducer

### Patch 1 — `polkitbackend: don't leak the synthetic caller used for self-invocations`

When `polkit_backend_interactive_authority_check_authorization()` is invoked with `caller == NULL` (the "called from ourselves" hack near the top of the function), it allocates a fresh `PolkitSystemBusName` via `polkit_system_bus_name_new()` and stores it in the local `caller` parameter. The function's `out:` cleanup never unrefs it, because in the normal D-Bus path `caller` is owned by the function's caller.

The fix tracks the synthesised caller separately as `local_caller` and unrefs it at `out:`; the normal caller-parameter-borrowed flow is unchanged.

**Verification:** under an ASAN build, exercise the `caller == NULL` branch by calling `polkit_backend_authority_check_authorization()` with `caller=NULL`. Without the patch, ASAN reports a leak rooted at `polkit_system_bus_name_new`. With the patch, clean. The branch isn't exercised by the in-tree code paths, so external triggering is hard — ASAN + a synthetic test is the most reliable verification.

### Patch 2 — `polkitbackend: avoid g_object_unref(NULL) in push_subject error path`

When `polkit_system_bus_name_get_process_sync()` fails (e.g. the bus name vanished mid-query), `push_subject()` `goto`s `out:` with `process` still `NULL`. The `out:` block then calls `g_object_unref(process)` because the subject is still a `SYSTEM_BUS_NAME`, firing `GLib-GObject-CRITICAL ** g_object_unref: assertion 'G_IS_OBJECT (object)' failed` in the journal.

The fix guards the unref with `process != NULL`. Trivially small and matches the cleanup style of the recently merged GError-related fixes.

**Verification:** send a `CheckAuthorization` for a system bus name that vanishes mid-query and watch the journal for the absence of the `G_IS_OBJECT` critical. The race is hard to hit reliably; for practical purposes code review is sufficient.
