### PR TITLE
polkitbackend: drop the already resolved agent object from the hashmap

### DIFF
--- a/src/polkitbackend/polkitbackendinteractiveauthority.c
+++ b/src/polkitbackend/polkitbackendinteractiveauthority.c
@@ -2108,6 +2108,24 @@ get_authentication_agent_by_unique_system_bus_name (PolkitBackendInteractiveAuth
 }
 
 static void
+remove_authentication_agent (GHashTable          *hash_table,
+                             AuthenticationAgent *agent_to_remove)
+{
+    GHashTableIter hash_iter;
+    AuthenticationAgent *agent;
+
+    g_hash_table_iter_init (&hash_iter, hash_table);
+    while (g_hash_table_iter_next (&hash_iter, NULL, (gpointer) &agent))
+      {
+        if (agent == agent_to_remove)
+          {
+            g_hash_table_iter_remove (&hash_iter);
+            return;
+          }
+      }
+}
+
+static void
 authentication_agent_begin_cb (GDBusProxy   *proxy,
                                GAsyncResult *res,
                                gpointer      user_data)
@@ -3053,7 +3071,7 @@ polkit_backend_interactive_authority_unregister_authentication_agent (PolkitBack
   authentication_agent_cancel_all_sessions (agent);
   /* this works because we have exactly one agent per session */
   /* this frees agent... */
-  g_hash_table_remove (priv->hash_scope_to_authentication_agent, agent->scope);
+  remove_authentication_agent (priv->hash_scope_to_authentication_agent, agent);
 
   g_signal_emit_by_name (authority, "changed");
 
@@ -3212,7 +3230,7 @@ polkit_backend_interactive_authority_system_bus_name_owner_changed (PolkitBacken
           authentication_agent_cancel_all_sessions (agent);
           /* this works because we have exactly one agent per session */
           /* this frees agent... */
-          g_hash_table_remove (priv->hash_scope_to_authentication_agent, agent->scope);
+          remove_authentication_agent (priv->hash_scope_to_authentication_agent, agent);
 
           g_signal_emit_by_name (authority, "changed");
         }


### PR DESCRIPTION
instead of resolving it again via g_hash_table_remove().

If a process for which we hold a pidfd has exited and been already
reaped, the "Pid" pidfd field will contain -1 instead of the original
process PID. This is especially problematic in polkit_unix_process_hash()
where we use the PID as one of the inputs to the hashing function, so
returning anything else than the original PID will causes us to hit a
different bucket with some annoying consequences.

This causes a nasty race with pkttyagent which eventually leaks two
pidfds:

  - pkttyagent starts and calls RegisterAuthenticationAgent over D-Bus;
    the subject of this call is PolkitUnixProcess (the pkttyagent
    itself)
  - polkit_backend_interactive_authority_register_authentication_agent()
    allocates a new agent and adds it into the hash table via
    g_hash_table_insert(); the function calculates the hash for this
    entry via polkit_subject_hash() which calls
    polkit_unix_process_hash()
  - here we can resolve the pidfd to PID, so the target bucket is PID +
    process' start time
  - pkttyagent dies with SIGTERM, and is eventually reaped by PID 1
  - D-Bus broker notices pkttyagent died and emits NameOwnerChanged
    signal - this gets queued into polkitd's main event loop, but it
    might not be picked up right away if polkit is busy with other stuff
  - when polkitd finally handles the NameOwnerChanged signal (in
    on_name_owner_changed_signal()) it calls
    polkit_backend_interactive_authority_system_bus_name_owner_changed()
    which will get the agent object via
    get_authentication_agent_by_unique_system_bus_name() and then tries
    to free the agent's resources by calling g_hash_table_remove()
  - polkit_unix_process_hash() is called again to get the hash of the
    bucket, but this time when we try to resolve the pidfd we get -1, so
    polkit_unix_process_get_pid() returns 0; this means that the target
    bucket is 0 + process' start time, which is a different bucket!
  - we don't check the return value from g_hash_table_remove(), so the
    fact that we didn't remove anything from the hash table is silently
    ignored
  - this means that the agent (AuthenticationAgent) remains in the hash
    table practically forever, but it still holds two pidfds in
    agent->scope, namely process->pidfd and process->ppidfd; both of
    these are leaked

This also means if you call pkttyagent enough times, you will eventually
hit the NOFILE rlimit. When this happens and GLib attempts to call
eventfd()/pipe() from g_wakeup_new(), it'll return EMFILE/ENFILE and
polkit crashes with SIGTRAP (as GLib in this case calls _g_log_abort()
that usually calls __builtin_trap()). The impact here is not that
severe, since polkit should start back up once something else requests
polkit auth, as it's D-Bus activated.

Given we already have a resolved AuthenticationAgent in both cases where
we call g_hash_table_remove(), let's use it to drop it from the hashmap
directly via g_hash_table_iter_remove() instead of resolving it again.
This way, we avoid the problematic bucket hash resolution and hence the
race

---

@bluca this is one of the _more_ interesting issues I mentioned earlier today. I'm not 100% sure about all the security implications of the fix, so please yell if this is wrong. I can also provide a very simple reproducer if needed.