### PR TITLE
Draining loop can keep polkit busy

### DIFF
--- a/src/polkitagent/polkitagenthelperprivate.c
+++ b/src/polkitagent/polkitagenthelperprivate.c
@@ -70,10 +70,6 @@ read_cookie (int argc, char **argv)
         }
       if (buf[strlen (buf) - 1] != '\n')
         {
-          /* Cookie too long - drain remaining input and reject */
-          int c;
-          while ((c = getchar ()) != '\n' && c != EOF)
-            ;
           errno = EOVERFLOW;
           return NULL;
         }


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
The draining loop is not really appropriate for pipe input, especially in a daemon.



## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #
