### PR TITLE
systemd: start after systemd-sysusers to avoid race condition

### DIFF
--- a/data/polkit.service.in
+++ b/data/polkit.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Authorization Manager
 Documentation=man:polkit(8)
+After=systemd-sysusers.service
 
 [Service]
 Type=notify-reload


### PR DESCRIPTION
The polkit service unit is dependent on the configured polkit user (@polkitd_user@) which needs to be created before the service is started.

When installing the package a race condition might occur when the service unit is started before the polkit user exists.

To fix the race condition, the polkit service unit needs to use After= [1] to order itself after systemd-sysusers.service [2] which is responsible for creating users on systems.

[1] https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Before=
[2] https://www.freedesktop.org/software/systemd/man/latest/systemd-sysusers.html
