### PR TITLE
Serialize polkit subject pidfds correctly

### DIFF
--- a/src/polkit/polkitauthority.c
+++ b/src/polkit/polkitauthority.c
@@ -934,7 +934,7 @@ polkit_authority_check_authorization (PolkitAuthority               *authority,
   g_dbus_proxy_call (authority->proxy,
                      "CheckAuthorization",
                      g_variant_new ("(@(sa{sv})s@a{ss}us)",
-                                    polkit_subject_to_gvariant (subject), /* A floating value */
+                                    polkit_subject_to_gvariant (subject, NULL), /* A floating value */
                                     action_id,
                                     polkit_details_to_gvariant (details), /* A floating value */
                                     flags,
@@ -1084,7 +1084,7 @@ polkit_authority_register_authentication_agent (PolkitAuthority      *authority,
   g_dbus_proxy_call (authority->proxy,
                      "RegisterAuthenticationAgent",
                      g_variant_new ("(@(sa{sv})ss)",
-                                    polkit_subject_to_gvariant (subject), /* A floating value */
+                                    polkit_subject_to_gvariant (subject, NULL), /* A floating value */
                                     locale,
                                     object_path),
                      G_DBUS_CALL_FLAGS_NONE,
@@ -1229,7 +1229,7 @@ polkit_authority_register_authentication_agent_with_options (PolkitAuthority    
   g_return_if_fail (g_variant_is_object_path (object_path));
   g_return_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
 
-  subject_value = polkit_subject_to_gvariant (subject);
+  subject_value = polkit_subject_to_gvariant (subject, NULL);
   g_variant_ref_sink (subject_value);
   if (options != NULL)
     {
@@ -1395,7 +1395,7 @@ polkit_authority_unregister_authentication_agent (PolkitAuthority      *authorit
   g_dbus_proxy_call (authority->proxy,
                      "UnregisterAuthenticationAgent",
                      g_variant_new ("(@(sa{sv})s)",
-                                    polkit_subject_to_gvariant (subject), /* A floating value */
+                                    polkit_subject_to_gvariant (subject, NULL), /* A floating value */
                                     object_path),
                      G_DBUS_CALL_FLAGS_NONE,
                      -1,
@@ -1536,7 +1536,7 @@ polkit_authority_authentication_agent_response_with_subject (PolkitAuthority    
                      g_variant_new ("(s@(sa{sv})@(sa{sv}))",
                                     cookie,
                                     polkit_identity_to_gvariant (identity), /* Floating value */
-                                    polkit_subject_to_gvariant (subject)), /* Floating value */
+                                    polkit_subject_to_gvariant (subject, NULL)), /* Floating value */
                      G_DBUS_CALL_FLAGS_NONE,
                      -1,
                      cancellable,
@@ -1771,7 +1771,7 @@ polkit_authority_enumerate_temporary_authorizations (PolkitAuthority     *author
   g_dbus_proxy_call (authority->proxy,
                      "EnumerateTemporaryAuthorizations",
                      g_variant_new ("(@(sa{sv}))",
-                                    polkit_subject_to_gvariant (subject)), /* A floating value */
+                                    polkit_subject_to_gvariant (subject, NULL)), /* A floating value */
                      G_DBUS_CALL_FLAGS_NONE,
                      -1,
                      cancellable,
@@ -1920,7 +1920,7 @@ polkit_authority_revoke_temporary_authorizations (PolkitAuthority     *authority
   g_dbus_proxy_call (authority->proxy,
                      "RevokeTemporaryAuthorizations",
                      g_variant_new ("(@(sa{sv}))",
-                                    polkit_subject_to_gvariant (subject)), /* A floating value */
+                                    polkit_subject_to_gvariant (subject, NULL)), /* A floating value */
                      G_DBUS_CALL_FLAGS_NONE,
                      -1,
                      cancellable,

--- a/src/polkit/polkitauthority.c
+++ b/src/polkit/polkitauthority.c
@@ -1525,26 +1525,31 @@ polkit_authority_authentication_agent_response_with_subject (PolkitAuthority    
    * this one is called from a socket-activated service, rather than a
    * setuid helper invoked directly by the authenticating process.
    */
+  GUnixFDList *fd_list;
   g_return_if_fail (POLKIT_IS_AUTHORITY (authority));
   g_return_if_fail (cookie != NULL);
   g_return_if_fail (POLKIT_IS_IDENTITY (identity));
   g_return_if_fail (POLKIT_IS_SUBJECT (subject));
   g_return_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
 
-  g_dbus_proxy_call (authority->proxy,
+  fd_list = g_unix_fd_list_new();
+  g_dbus_proxy_call_with_unix_fd_list (authority->proxy,
                      "AuthenticationAgentResponse3",
                      g_variant_new ("(s@(sa{sv})@(sa{sv}))",
                                     cookie,
                                     polkit_identity_to_gvariant (identity), /* Floating value */
-                                    polkit_subject_to_gvariant (subject, NULL)), /* Floating value */
+                                    polkit_subject_to_gvariant (subject, fd_list)), /* Floating value */
                      G_DBUS_CALL_FLAGS_NONE,
                      -1,
+                     fd_list,
                      cancellable,
                      generic_async_cb,
                      g_simple_async_result_new (G_OBJECT (authority),
                                                 callback,
                                                 user_data,
                                                 polkit_authority_authentication_agent_response));
+
+  g_object_unref(fd_list);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/polkit/polkitprivate.h
+++ b/src/polkit/polkitprivate.h
@@ -62,7 +62,8 @@ PolkitTemporaryAuthorization *polkit_temporary_authorization_new    (const gchar
                                                                      guint64                       time_expires);
 PolkitTemporaryAuthorization *polkit_temporary_authorization_new_for_gvariant (GVariant *value,
                                                                                GError   **error);
-GVariant *polkit_temporary_authorization_to_gvariant (PolkitTemporaryAuthorization *authorization);
+GVariant *polkit_temporary_authorization_to_gvariant (PolkitTemporaryAuthorization *authorization,
+    GUnixFDList *fd_list);
 
 GVariant *polkit_details_to_gvariant (PolkitDetails *details);
 PolkitDetails *polkit_details_new_for_gvariant (GVariant *value);

--- a/src/polkit/polkitprivate.h
+++ b/src/polkit/polkitprivate.h
@@ -41,7 +41,7 @@
 PolkitActionDescription  *polkit_action_description_new_for_gvariant (GVariant *value);
 GVariant *polkit_action_description_to_gvariant (PolkitActionDescription *action_description);
 
-GVariant *polkit_subject_to_gvariant (PolkitSubject *subject);
+GVariant *polkit_subject_to_gvariant (PolkitSubject *subject, GUnixFDList *fd_list);
 GVariant *polkit_identity_to_gvariant (PolkitIdentity *identity);
 
 gint polkit_unix_process_get_racy_uid__ (PolkitUnixProcess *process, GError **error);

--- a/src/polkit/polkitsubject.c
+++ b/src/polkit/polkitsubject.c
@@ -297,10 +297,11 @@ polkit_subject_from_string  (const gchar   *str,
 
 /* Note that this returns a floating value. */
 GVariant *
-polkit_subject_to_gvariant (PolkitSubject *subject)
+polkit_subject_to_gvariant (PolkitSubject *subject, GUnixFDList *fd_list)
 {
   GVariantBuilder builder;
   GVariant *dict;
+  gint idx;
   const gchar *kind;
 
   kind = "";
@@ -315,9 +316,10 @@ polkit_subject_to_gvariant (PolkitSubject *subject)
                              g_variant_new_uint64 (polkit_unix_process_get_start_time (POLKIT_UNIX_PROCESS (subject))));
       g_variant_builder_add (&builder, "{sv}", "uid",
                              g_variant_new_int32 (polkit_unix_process_get_uid (POLKIT_UNIX_PROCESS (subject))));
-      if (polkit_unix_process_get_pidfd_is_safe(POLKIT_UNIX_PROCESS (subject)))
-        g_variant_builder_add (&builder, "{sv}", "pidfd",
-                               g_variant_new_handle (polkit_unix_process_get_pidfd (POLKIT_UNIX_PROCESS (subject))));
+      if (polkit_unix_process_get_pidfd_is_safe(POLKIT_UNIX_PROCESS (subject)) && fd_list) {
+        idx = g_unix_fd_list_append(fd_list, polkit_unix_process_get_pidfd(POLKIT_UNIX_PROCESS (subject)), NULL);
+        g_variant_builder_add (&builder, "{sv}", "pidfd", g_variant_new_handle (idx));
+      }
     }
   else if (POLKIT_IS_UNIX_SESSION (subject))
     {

--- a/src/polkit/polkittemporaryauthorization.c
+++ b/src/polkit/polkittemporaryauthorization.c
@@ -215,7 +215,7 @@ polkit_temporary_authorization_to_gvariant (PolkitTemporaryAuthorization *author
   return g_variant_new ("(ss@(sa{sv})tt)",
                         authorization->id,
                         authorization->action_id,
-                        polkit_subject_to_gvariant (authorization->subject), /* A floating value */
+                        polkit_subject_to_gvariant (authorization->subject, NULL), /* A floating value */
                         authorization->time_obtained,
                         authorization->time_expires);
 }

--- a/src/polkit/polkittemporaryauthorization.c
+++ b/src/polkit/polkittemporaryauthorization.c
@@ -210,12 +210,12 @@ polkit_temporary_authorization_new_for_gvariant (GVariant  *value,
 
 /* Note that this returns a floating value. */
 GVariant *
-polkit_temporary_authorization_to_gvariant (PolkitTemporaryAuthorization *authorization)
+polkit_temporary_authorization_to_gvariant (PolkitTemporaryAuthorization *authorization, GUnixFDList *fd_list)
 {
   return g_variant_new ("(ss@(sa{sv})tt)",
                         authorization->id,
                         authorization->action_id,
-                        polkit_subject_to_gvariant (authorization->subject, NULL), /* A floating value */
+                        polkit_subject_to_gvariant (authorization->subject, fd_list), /* A floating value */
                         authorization->time_obtained,
                         authorization->time_expires);
 }

--- a/src/polkitbackend/polkitbackendauthority.c
+++ b/src/polkitbackend/polkitbackendauthority.c
@@ -1266,8 +1266,10 @@ server_handle_enumerate_temporary_authorizations (Server                 *server
   GList *authorizations;
   GList *l;
   GVariantBuilder builder;
+  GUnixFDList *fd_list;
 
   subject = NULL;
+  fd_list = NULL;
 
   g_variant_get (parameters,
                  "(@(sa{sv}))",
@@ -1296,20 +1298,25 @@ server_handle_enumerate_temporary_authorizations (Server                 *server
     }
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(ss(sa{sv})tt)"));
+  fd_list = g_unix_fd_list_new();
   for (l = authorizations; l != NULL; l = l->next)
     {
       PolkitTemporaryAuthorization *a = POLKIT_TEMPORARY_AUTHORIZATION (l->data);
       g_variant_builder_add_value (&builder,
-                                   polkit_temporary_authorization_to_gvariant (a)); /* A floating value */
+                                   polkit_temporary_authorization_to_gvariant (a, fd_list)); /* A floating value */
     }
   g_list_foreach (authorizations, (GFunc) g_object_unref, NULL);
   g_list_free (authorizations);
-  g_dbus_method_invocation_return_value (invocation, g_variant_new ("(a(ss(sa{sv})tt))", &builder));
+  g_dbus_method_invocation_return_value_with_unix_fd_list (invocation,
+                                                           g_variant_new ("(a(ss(sa{sv})tt))", &builder),
+                                                           fd_list);
 
  out:
   g_variant_unref (subject_gvariant);
   if (subject != NULL)
     g_object_unref (subject);
+  if (fd_list != NULL)
+    g_object_unref(fd_list);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
Originally submitted to polkit-security, but I think the risk is not too severe so resubmitting here.

DBus passes unix-fds by index, and declares the number of fds passed in in the message header. Presently, polkit serializes the pidfd of a unix-process subject as if it were the index, and fails to actually pass the fd.

If the client is careful, this will be caught as a protocol error:

```
  $ run0 whoami
  root
  $ busctl --verbose call \
            org.freedesktop.PolicyKit1
            /org/freedesktop/PolicyKit1/Authority
            org.freedesktop.PolicyKit1.Authority
            EnumerateTemporaryAuthorizations '(sa{sv})'
            unix-session 1 session-id s $XDG_SESSION_ID

  Failed to dump DBus message: Bad message
  MESSAGE "a(ss(sa{sv})tt)" {
  [...]
         DICT_ENTRY "sv" {
             STRING "pidfd";
             VARIANT "h" {
  $ echo $?
  1
```

Correct the serialization of pidfds so that they can be passed correctly in the methods that use them.