### PR TITLE
agent helper: Allow access to tpm in agent helper sandbox

### DIFF
--- a/data/polkit-agent-helper@.service.in
+++ b/data/polkit-agent-helper@.service.in
@@ -15,6 +15,7 @@ LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
 PrivateDevices=yes
+DeviceAllow=char-tpm rw
 PrivateNetwork=yes
 PrivateTmp=yes
 ProtectControlGroups=yes


### PR DESCRIPTION
## Summary
One line change to polkit-agent-helper service unit to allow access to tpm devices an explicit DeviceAllow entry.

This allows access for pam modules that make use of the tpm to be utilized with polkit.

Allowing access to the tpm (trusted platform module) is useful for authorization and authentication tasks, such as gating polkit authorization on a tpm backed credential or system PCR registers.

Residual risk is primarily DoS via lockout exhaustion attacks and is bounded by the TPM's own auth/DA controls; all other unit hardening is unchanged and DevicePolicy is retained as closed.

See issue https://github.com/RazeLighter777/pinpam/issues/4#issuecomment-3815461955 for an example of an upstream project requiring a workaround for this issue.





