### PR TITLE
Fix build on NetBSD & Solaris

### DIFF
--- a/src/polkit/polkitunixprocess.c
+++ b/src/polkit/polkitunixprocess.c
@@ -27,6 +27,11 @@
 #include <sys/vfs.h>
 #endif
 #include <sys/types.h>
+#ifdef HAVE_SOLARIS
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <procfs.h>
+#endif
 #ifdef HAVE_FREEBSD
 #include <sys/param.h>
 #include <sys/sysctl.h>

--- a/src/polkit/polkitunixprocess.c
+++ b/src/polkit/polkitunixprocess.c
@@ -194,7 +194,7 @@ enum
 
 static void subject_iface_init (PolkitSubjectIface *subject_iface);
 
-static guint64 get_start_time_for_pid (gint    pid,
+static guint64 get_start_time_for_pid (pid_t pid,
                                        GError **error);
 
 static gint

--- a/src/polkitagent/polkitagenthelper-pam.c
+++ b/src/polkitagent/polkitagenthelper-pam.c
@@ -144,7 +144,9 @@ main (int argc, char *argv[])
   if (argv[1] != NULL && strcmp (argv[1], "--socket-activated") == 0)
     {
       socklen_t socklen = sizeof(int);
+#ifdef SO_PEERCRED
       struct ucred ucred;
+#endif
 
       user_to_auth_free = read_cookie (argc, argv);
       if (!user_to_auth_free)
@@ -168,8 +170,12 @@ main (int argc, char *argv[])
           goto error;
         }
 
+#ifdef SO_PEERCRED
       socklen = sizeof(ucred);
       rc = getsockopt(STDIN_FILENO, SOL_SOCKET, SO_PEERCRED, &ucred, &socklen);
+#else
+      rc = -1;
+#endif
       if (rc < 0)
         {
           syslog (LOG_ERR, "Unable to get credentials from socket");
@@ -177,7 +183,9 @@ main (int argc, char *argv[])
           goto error;
         }
 
+#ifdef SO_PEERCRED
       uid = ucred.uid;
+#endif
     }
   else
     user_to_auth = argv[1];

--- a/src/polkitbackend/polkitbackendduktapeauthority.c
+++ b/src/polkitbackend/polkitbackendduktapeauthority.c
@@ -436,7 +436,7 @@ passwd = getpwuid (uid);
 if (passwd == NULL)
   {
     user_name = g_strdup_printf ("%d", (gint) uid);
-    g_warning ("Error looking up info for uid %d: %m", (gint) uid);
+    g_warning ("Error looking up info for uid %d", (gint) uid);
   }
 else
   {
@@ -474,7 +474,7 @@ else
                             gids,
                             &num_gids) < 0)
             {
-              g_warning ("Error looking up groups for uid %d: %m", (gint) uid);
+              g_warning ("Error looking up groups for uid %d: %s", (gint) uid, g_strerror(errno));
             }
           else
             {

--- a/src/polkitbackend/polkitd.c
+++ b/src/polkitbackend/polkitd.c
@@ -20,6 +20,7 @@
  */
 
 #include <signal.h>
+#include <errno.h>
 #include <stdlib.h>
 
 #include <glib-unix.h>
@@ -248,7 +249,7 @@ become_user (const gchar  *user,
   if (pw == NULL)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Error calling getpwnam(): %m");
+                   "Error calling getpwnam(): %s", g_strerror(errno));
       goto out;
     }
 
@@ -263,13 +264,13 @@ become_user (const gchar  *user,
   if (setgroups (0, NULL) != 0)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Error clearing groups: %m");
+                   "Error clearing groups: %s", g_strerror(errno));
       goto out;
     }
   if (initgroups (pw->pw_name, pw->pw_gid) != 0)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Error initializing groups: %m");
+                   "Error initializing groups: %s", g_strerror(errno));
       goto out;
     }
 
@@ -279,16 +280,16 @@ become_user (const gchar  *user,
       (getegid () != pw->pw_gid) || (getgid () != pw->pw_gid))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Error becoming real+effective uid %d and gid %d: %m",
-                   (int) pw->pw_uid, (int) pw->pw_gid);
+                   "Error becoming real+effective uid %d and gid %d: %s",
+                   (int) pw->pw_uid, (int) pw->pw_gid, g_strerror(errno));
       goto out;
     }
 
   if (chdir ("/") != 0)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Error changing to root directory %s: %m",
-                   pw->pw_dir);
+                   "Error changing to root directory %s: %s",
+                   pw->pw_dir, g_strerror(errno));
       goto out;
     }
 
@@ -346,7 +347,7 @@ main (int    argc,
         }
       else
         {
-          g_warning ("Error opening /dev/null: %m");
+          g_warning ("Error opening /dev/null: %s", g_strerror(errno));
         }
     }
 

--- a/src/programs/pkttyagent.c
+++ b/src/programs/pkttyagent.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdio.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <locale.h>
 #include <signal.h>
@@ -259,7 +260,7 @@ main (int argc, char *argv[])
     {
       if (close (opt_notify_fd) != 0)
         {
-          g_printerr ("Error closing notify-fd %d: %m\n", opt_notify_fd);
+          g_printerr ("Error closing notify-fd %d: %s\n", opt_notify_fd, g_strerror(errno));
           goto out;
         }
     }


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #
I've updated the pkgsrc package for polkit to 127, and I needed a new patch for fixing the build on NetBSD (for `SO_PEERCRED`, which NetBSD does not provide).

I've also included the existing patches from pkgsrc, please include them.


## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #

Fix the build on NetBSD and Solaris.

This replaces https://github.com/polkit-org/polkit/pull/624 now from a branch in this repository to simplify future change requests.