### PR TITLE
fix: reject UID/GID values exceeding G_MAXINT32 to prevent truncation

### DIFF
--- a/src/polkit/polkitidentity.c
+++ b/src/polkit/polkitidentity.c
@@ -19,6 +19,7 @@
  * Author: David Zeuthen <davidz@redhat.com>
  */
 
+#include <errno.h>
 #include <string.h>
 
 #include "polkitidentity.h"
@@ -156,22 +157,46 @@ polkit_identity_from_string  (const gchar   *str,
 
   if (g_str_has_prefix (str, "unix-user:"))
     {
+      errno = 0;
       val = g_ascii_strtoull (str + sizeof "unix-user:" - 1,
                               &endptr,
                               10);
       if (*endptr == '\0')
-        identity = polkit_unix_user_new ((gint) val);
+        {
+          if (errno == ERANGE || val > G_MAXUINT32)
+            {
+              g_set_error (error,
+                           POLKIT_ERROR,
+                           POLKIT_ERROR_FAILED,
+                           "UID value '%s' is out of range",
+                           str + sizeof "unix-user:" - 1);
+            }
+          else
+            identity = polkit_unix_user_new ((gint) val);
+        }
       else
         identity = polkit_unix_user_new_for_name (str + sizeof "unix-user:" - 1,
                                                  error);
     }
   else if (g_str_has_prefix (str, "unix-group:"))
     {
+      errno = 0;
       val = g_ascii_strtoull (str + sizeof "unix-group:" - 1,
                               &endptr,
                               10);
       if (*endptr == '\0')
-        identity = polkit_unix_group_new ((gint) val);
+        {
+          if (errno == ERANGE || val > G_MAXUINT32)
+            {
+              g_set_error (error,
+                           POLKIT_ERROR,
+                           POLKIT_ERROR_FAILED,
+                           "GID value '%s' is out of range",
+                           str + sizeof "unix-group:" - 1);
+            }
+          else
+            identity = polkit_unix_group_new ((gint) val);
+        }
       else
         identity = polkit_unix_group_new_for_name (str + sizeof "unix-group:" - 1,
                                                   error);

--- a/test/polkit/polkitidentitytest.c
+++ b/test/polkit/polkitidentitytest.c
@@ -60,6 +60,32 @@ test_string (const void *_subject)
 
 
 static void
+test_overflow_reject (const void *_subject)
+{
+  const gchar *subject = (const gchar *) _subject;
+  PolkitIdentity *identity;
+  GError *error = NULL;
+
+  identity = polkit_identity_from_string (subject, &error);
+  g_assert (identity == NULL);
+  g_assert_error (error, POLKIT_ERROR, POLKIT_ERROR_FAILED);
+  g_error_free (error);
+}
+
+static void
+test_overflow_accept (const void *_subject)
+{
+  const gchar *subject = (const gchar *) _subject;
+  PolkitIdentity *identity;
+  GError *error = NULL;
+
+  identity = polkit_identity_from_string (subject, &error);
+  g_assert (identity != NULL);
+  g_assert_no_error (error);
+  g_object_unref (identity);
+}
+
+static void
 test_gvariant (const void *_subject)
 {
   const gchar *subject = (const gchar *) _subject;
@@ -193,6 +219,32 @@ main (int argc, char *argv[])
 
   g_test_add_data_func ("/PolkitIdentity/user_gvariant", "unix-user:root", test_gvariant);
   g_test_add_data_func ("/PolkitIdentity/group_gvariant", "unix-group:root", test_gvariant);
+
+  /* UID overflow rejection tests */
+  g_test_add_data_func ("/PolkitIdentity/uid_overflow_wrap_to_root",
+                        "unix-user:4294967296", test_overflow_reject);
+  g_test_add_data_func ("/PolkitIdentity/uid_overflow_wrap_to_root_2",
+                        "unix-user:8589934592", test_overflow_reject);
+  g_test_add_data_func ("/PolkitIdentity/uid_overflow_maxuint32",
+                        "unix-user:4294967295", test_overflow_reject);
+
+  /* GID overflow rejection tests */
+  g_test_add_data_func ("/PolkitIdentity/gid_overflow_wrap_to_root",
+                        "unix-group:4294967296", test_overflow_reject);
+  g_test_add_data_func ("/PolkitIdentity/gid_overflow_wrap_to_root_2",
+                        "unix-group:8589934592", test_overflow_reject);
+  g_test_add_data_func ("/PolkitIdentity/gid_overflow_maxuint32",
+                        "unix-group:4294967295", test_overflow_reject);
+
+  /* High UID/GID acceptance tests */
+  g_test_add_data_func ("/PolkitIdentity/uid_highuid_maxint_plus1",
+                        "unix-user:2147483648", test_overflow_accept);
+  g_test_add_data_func ("/PolkitIdentity/uid_highuid_maxint",
+                        "unix-user:2147483647", test_overflow_accept);
+  g_test_add_data_func ("/PolkitIdentity/gid_highuid_maxint_plus1",
+                        "unix-group:2147483648", test_overflow_accept);
+  g_test_add_data_func ("/PolkitIdentity/gid_highuid_maxint",
+                        "unix-group:2147483647", test_overflow_accept);
 
   add_comparison_tests ();
 


### PR DESCRIPTION
● fix: reject UID/GID values exceeding G_MAXUINT32 to prevent integer truncation

  ## Summary

  polkit_identity_from_string() parses unix-user: and unix-group: identity strings by converting the numeric portion from guint64 to gint with no bounds check. Values where val % 2^32 == 0 wrap to uid/gid 0
  (root): unix-user:4294967296, 8589934592, 12884901888 all produce uid=0.

  ## Fix

  Add errno=0 before g_ascii_strtoull() and check errno == ERANGE || val > G_MAXUINT32 before the (gint) cast in both the unix-user: and unix-group: branches. Out-of-range values set a GError instead of
  producing a truncated identity. Also add #include <errno.h> which was missing.

  G_MAXUINT32 (not G_MAXINT) is the correct bound because uid_t is a 32-bit unsigned type. Values in (G_MAXINT, G_MAXUINT32] are valid high UIDs — polkit's own test data uses UID 4000000000.

  ## Tests

  Added 10 edge-value tests in polkitidentitytest.c: 6 rejection tests (wrap-to-root and G_MAXUINT32 for both uid/gid) and 4 acceptance tests (G_MAXINT and G_MAXINT+1 for both uid/gid).

  ## Affected code

  src/polkit/polkitidentity.c, test/polkit/polkitidentitytest.c
