### PR TITLE
Fix docs build warnings

### DIFF
--- a/docs/man/pkaction.xml
+++ b/docs/man/pkaction.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="pkaction.1" xmlns:xi="http://www.w3.org/2003/XInclude">
   <refentryinfo>
@@ -91,11 +92,11 @@
   <refsect1 id="pkaction-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="pkcheck.1"><citerefentry><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkttyagent.1"><citerefentry><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="pkcheck.1"><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkttyagent.1"><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry>
     </para>
   </refsect1>
 </refentry>

--- a/docs/man/pkcheck.xml
+++ b/docs/man/pkcheck.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="pkcheck.1" xmlns:xi="http://www.w3.org/2003/XInclude">
   <refentryinfo>
@@ -213,11 +214,11 @@ KEY3=VALUE3
   <refsect1 id="pkcheck-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="pkaction.1"><citerefentry><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkttyagent.1"><citerefentry><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="pkaction.1"><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkttyagent.1"><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry>
     </para>
   </refsect1>
 </refentry>

--- a/docs/man/pkexec.xml
+++ b/docs/man/pkexec.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="pkexec.1" xmlns:xi="http://www.w3.org/2003/XInclude">
   <refentryinfo>
@@ -273,11 +274,11 @@ for n in range(len(sys.argv)):
   <refsect1 id="pkexec-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="pkaction.1"><citerefentry><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkcheck.1"><citerefentry><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkttyagent.1"><citerefentry><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="pkaction.1"><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkcheck.1"><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkttyagent.1"><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry>
     </para>
   </refsect1>
 </refentry>

--- a/docs/man/pkttyagent.xml
+++ b/docs/man/pkttyagent.xml
@@ -2,6 +2,8 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
+<!ENTITY % local.literal.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="pkttyagent.1" xmlns:xi="http://www.w3.org/2003/XInclude">
   <refentryinfo>
@@ -77,8 +79,8 @@
     </para>
     <para>
       To get notified when the authentication agent has been
-      registered either listen to the <link
-      linkend="eggdbus-signal-org.freedesktop.PolicyKit1.Authority::Changed">Changed</link>
+      registered either listen to the <literal
+      linkend="eggdbus-signal-org.freedesktop.PolicyKit1.Authority::Changed">Changed</literal>
       D-Bus signal or use <option>--notify-fd</option> to pass the
       number of a file descriptor that has been passed to the
       program. This file descriptor will then be closed when the
@@ -145,11 +147,11 @@
   <refsect1 id="pkttyagent-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="pkaction.1"><citerefentry><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkcheck.1"><citerefentry><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="pkaction.1"><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkcheck.1"><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>
     </para>
   </refsect1>
 </refentry>

--- a/docs/man/polkit-agent-helper.xml
+++ b/docs/man/polkit-agent-helper.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="polkit-agent-helper.8">
   <refentryinfo>
@@ -76,8 +77,7 @@
     </para>
 
     <para>
-      See the <link
-      linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>
+      See the <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>
       man page for an overview of how authentication agents interact
       with the rest of the polkit architecture.
     </para>
@@ -192,9 +192,9 @@ ProtectHome=read-only
   <refsect1 id="polkit-agent-helper-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="pkttyagent.1"><citerefentry><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
+      <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="pkttyagent.1"><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd.exec</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>pam</refentrytitle><manvolnum>8</manvolnum></citerefentry>
     </para>

--- a/docs/man/polkit.xml
+++ b/docs/man/polkit.xml
@@ -2,6 +2,8 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
+<!ENTITY % local.type.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="polkit.8" xmlns:xi="http://www.w3.org/2003/XInclude">
   <refentryinfo>
@@ -36,7 +38,7 @@
 
     <para>
       The polkit authority is implemented as an system daemon,
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
       which itself has little privilege as it is running as the
       <emphasis>polkitd</emphasis> system user. Mechanisms, subjects
       and authentication agents communicate with the authority using
@@ -125,8 +127,8 @@ System Context         |                        |
       program as well as higher-level languages supporting <ulink
       url="https://live.gnome.org/GObjectIntrospection">GObjectIntrospection</ulink>
       such as JavaScript and Python.  A mechanism can also use the
-      D-Bus API or the <link
-      linkend="pkcheck.1"><citerefentry><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      D-Bus API or the
+      <citerefentry linkend="pkcheck.1"><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry>
       command to check authorizations. The
       <literal>libpolkit-agent-1</literal> library provides an
       abstraction of the native authentication system, e.g.
@@ -208,10 +210,10 @@ System Context         |                        |
       example, if launched from an
       <citerefentry><refentrytitle>ssh</refentrytitle><manvolnum>1</manvolnum></citerefentry>
       login) may not have an authentication agent associated with
-      them. Such applications may use the <link
-      linkend="PolkitAgentTextListener-struct">PolkitAgentTextListener</link>
+      them. Such applications may use the <type
+      linkend="PolkitAgentTextListener-struct">PolkitAgentTextListener</type>
       type or the
-      <link linkend="pkttyagent.1"><citerefentry><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      <citerefentry linkend="pkttyagent.1"><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry>
       helper so the user can authenticate using a textual interface.
     </para>
 
@@ -221,7 +223,7 @@ System Context         |                        |
       run as a systemd socket-activated service it operates in a
       restricted sandbox; PAM module creators that need additional
       access should consult the
-      <link linkend="polkit-agent-helper.8"><citerefentry><refentrytitle>polkit-agent-helper</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>
+      <citerefentry linkend="polkit-agent-helper.8"><refentrytitle>polkit-agent-helper</refentrytitle><manvolnum>8</manvolnum></citerefentry>
       man page for guidance on shipping drop-in overrides.
     </para>
   </refsect1>
@@ -443,7 +445,7 @@ System Context         |                        |
     </para>
     <para>
       To list installed polkit actions, use the
-      <link linkend="pkaction.1"><citerefentry><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      <citerefentry linkend="pkaction.1"><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry>
       command.
     </para>
 
@@ -453,7 +455,7 @@ System Context         |                        |
         The <literal>org.freedesktop.policykit.exec.path</literal>
         annotation is used by the <command>pkexec</command> program
         shipped with polkit - see the
-        <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+        <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         man page for details.
       </para>
       <para>
@@ -474,8 +476,8 @@ System Context         |                        |
         this annotation is not specified, then only root can query
         whether a client running as a different user is authorized for
         an action.  The value of this annotation is a string
-        containing a space-separated list of <link
-        linkend="PolkitIdentity-struct">PolkitIdentity</link> entries,
+        containing a space-separated list of <type
+        linkend="PolkitIdentity-struct">PolkitIdentity</type> entries,
         for example <literal>"unix-user:42
         unix-user:colord"</literal>.  A typical use of this annotation
         is for a daemon process that runs as a system user rather than
@@ -730,7 +732,7 @@ May 24 14:28:50 thinkpad polkitd[32217]: /etc/polkit-1/rules.d/10-test.rules:4: 
       <para>
         The <function>lookup()</function> method is used to lookup the
         polkit variables passed from the mechanism. For example, the
-        <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+        <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         mechanism sets the variable <parameter>program</parameter>
         which can be obtained in JavaScript using the expression
         <literal>action.lookup("program")</literal>. If there is
@@ -949,7 +951,7 @@ polkit.addRule(function(action, subject) {
       <para>
         The following example shows how the authorization decision
         can depend on variables passed by the
-        <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+        <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         mechanism:
       </para>
       <programlisting><![CDATA[
@@ -1020,11 +1022,11 @@ polkit.addRule(function(action, subject) {
   <refsect1 id="polkit-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="pkaction.1"><citerefentry><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkcheck.1"><citerefentry><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkttyagent.1"><citerefentry><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="pkaction.1"><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkcheck.1"><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkttyagent.1"><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry>
     </para>
   </refsect1>
 </refentry>

--- a/docs/man/polkitd.conf.xml
+++ b/docs/man/polkitd.conf.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="polkitd.conf.5">
   <refentryinfo>
@@ -61,8 +62,8 @@
   <refsect1 id="polkitd-conf-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkitd.8"><citerefentry><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
+      <citerefentry linkend="polkitd.8"><refentrytitle>polkitd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>
     </para>
   </refsect1>
 </refentry>

--- a/docs/man/polkitd.conf.xml
+++ b/docs/man/polkitd.conf.xml
@@ -52,6 +52,12 @@
     </refsect2>
   </refsect1>
 
+  <refsect1 id="polkitd-conf-author"><title>AUTHOR</title>
+    <para>
+      Written by the polkit contributors.
+    </para>
+  </refsect1>
+
   <refsect1 id="polkitd-conf-see-also">
     <title>SEE ALSO</title>
     <para>

--- a/docs/man/polkitd.xml
+++ b/docs/man/polkitd.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 <!ENTITY version SYSTEM "../version.xml">
+<!ENTITY % local.citerefentry.attrib "linkend CDATA #IMPLIED">
 ]>
 <refentry id="polkitd.8">
   <refentryinfo>
@@ -41,8 +42,8 @@
     </para>
 
     <para>
-      <command>polkitd</command> may be configured via the <link
-      linkend="polkitd.conf.5"><citerefentry><refentrytitle>polkitd.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry></link>
+      <command>polkitd</command> may be configured via the
+      <citerefentry linkend="polkitd.conf.5"><refentrytitle>polkitd.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>
       configuration file.
     </para>
 
@@ -54,8 +55,7 @@
     </para>
 
     <para>
-      See the <link
-      linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>
+      See the <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>
       man page for more information.
 
     </para>
@@ -80,11 +80,11 @@
   <refsect1 id="polkitd-see-also">
     <title>SEE ALSO</title>
     <para>
-      <link linkend="polkit.8"><citerefentry><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry></link>,
-      <link linkend="pkaction.1"><citerefentry><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkcheck.1"><citerefentry><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkexec.1"><citerefentry><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
-      <link linkend="pkttyagent.1"><citerefentry><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry></link>,
+      <citerefentry linkend="polkit.8"><refentrytitle>polkit</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry linkend="pkaction.1"><refentrytitle>pkaction</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkcheck.1"><refentrytitle>pkcheck</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkexec.1"><refentrytitle>pkexec</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry linkend="pkttyagent.1"><refentrytitle>pkttyagent</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>dbus-daemon</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>
     </para>

--- a/docs/polkit/polkit-1-docs.xml
+++ b/docs/polkit/polkit-1-docs.xml
@@ -57,7 +57,9 @@
   <part id="manpages">
     <title>Manual Pages</title>
     <xi:include href="../man/polkit.xml"/>
+    <xi:include href="../man/polkit-agent-helper.xml"/>
     <xi:include href="../man/polkitd.xml"/>
+    <xi:include href="../man/polkitd.conf.xml"/>
     <xi:include href="../man/pkcheck.xml"/>
     <xi:include href="../man/pkaction.xml"/>
     <xi:include href="../man/pkexec.xml"/>

--- a/src/polkit/meson.build
+++ b/src/polkit/meson.build
@@ -123,7 +123,7 @@ pkg.generate(
 if enable_introspection
   libpolkit_gobject_gir = gnome.generate_gir(
     libpolkit_gobject,
-    sources: sources + headers,
+    sources: sources + headers + files('polkittypes.h'),
     extra_args: c_flags,
     nsversion: pk_gir_version,
     namespace: pk_gir_ns,


### PR DESCRIPTION
There's a bunch of warnings when building docs:

```
[28/101] Generating docs/man/polkitd.conf.5 with a custom command
Warn: meta author : no refentry/info/author                        polkitd.conf
Note: meta author : see http://www.docbook.org/tdg5/en/html/autho  polkitd.conf
Warn: meta author : no author data, so inserted a fixme            polkitd.conf
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "polkit.8".
Note: Writing polkitd.conf.5
[29/101] Generating docs/man/polkit-agent-helper.8 with a custom command
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "pkttyagent.1".
Note: Writing polkit-agent-helper.8
[31/101] Generating docs/man/pkttyagent.1 with a custom command
Error: no ID for constraint linkend: "eggdbus-signal-org.freedesktop.PolicyKit1.Authority::Changed".
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "pkaction.1".
Error: no ID for constraint linkend: "pkcheck.1".
Error: no ID for constraint linkend: "pkexec.1".
Note: Writing pkttyagent.1
[32/101] Generating docs/man/pkaction.1 with a custom command
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "pkcheck.1".
Error: no ID for constraint linkend: "pkexec.1".
Error: no ID for constraint linkend: "pkttyagent.1".
Note: Writing pkaction.1
[33/101] Generating docs/man/pkcheck.1 with a custom command
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "pkaction.1".
Error: no ID for constraint linkend: "pkexec.1".
Error: no ID for constraint linkend: "pkttyagent.1".
Note: Writing pkcheck.1
[34/101] Generating docs/man/polkitd.8 with a custom command
Error: no ID for constraint linkend: "polkitd.conf.5".
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "pkaction.1".
Error: no ID for constraint linkend: "pkcheck.1".
Error: no ID for constraint linkend: "pkexec.1".
Error: no ID for constraint linkend: "pkttyagent.1".
Note: Writing polkitd.8
[35/101] Generating docs/man/pkexec.1 with a custom command
Error: no ID for constraint linkend: "polkit.8".
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "pkaction.1".
Error: no ID for constraint linkend: "pkcheck.1".
Error: no ID for constraint linkend: "pkttyagent.1".
Note: Writing pkexec.1
[36/101] Generating docs/man/polkit.8 with a custom command
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "pkcheck.1".
Error: no ID for constraint linkend: "PolkitAgentTextListener-struct".
Error: no ID for constraint linkend: "pkttyagent.1".
Error: no ID for constraint linkend: "polkit-agent-helper.8".
Error: no ID for constraint linkend: "pkaction.1".
Error: no ID for constraint linkend: "pkexec.1".
Error: no ID for constraint linkend: "PolkitIdentity-struct".
Error: no ID for constraint linkend: "pkexec.1".
Error: no ID for constraint linkend: "pkexec.1".
Error: no ID for constraint linkend: "polkitd.8".
Error: no ID for constraint linkend: "pkaction.1".
Error: no ID for constraint linkend: "pkcheck.1".
Error: no ID for constraint linkend: "pkexec.1".
Error: no ID for constraint linkend: "pkttyagent.1".
Note: Writing polkit.8
[97/101] Generating src/polkit/Polkit-1.0.gir with a custom command (wrapped by meson to set env)
<unknown>:: Warning: Polkit: (Interface)Identity: Couldn't find associated structure for 'Identity'
<unknown>:: Warning: Polkit: (Interface)Subject: Couldn't find associated structure for 'Subject'
[100/101] Generating src/polkitagent/PolkitAgent-1.0.typelib with a custom command
```