### PR TITLE
polkitagenthelper: identify the caller by its real uid

### DIFF
--- a/src/polkitagent/polkitagenthelper-bsdauth.c
+++ b/src/polkitagent/polkitagenthelper-bsdauth.c
@@ -114,7 +114,7 @@ main (int argc, char *argv[])
   /* now send a D-Bus message to the polkit daemon that
    * includes a) the cookie; and b) the user we authenticated
    */
-  if (!send_dbus_message (cookie, user_to_auth, -1, -1))
+  if (!send_dbus_message (cookie, user_to_auth, -1))
     {
 #ifdef PAH_DEBUG
       fprintf (stderr, "polkit-agent-helper-1: error sending D-Bus message to polkit daemon\n");

--- a/src/polkitagent/polkitagenthelper-pam.c
+++ b/src/polkitagent/polkitagenthelper-pam.c
@@ -86,7 +86,6 @@ main (int argc, char *argv[])
 {
   int rc;
   int pidfd = -1;
-  int uid = -1;
   int errval = 1;
   const char *user_to_auth;
   char *user_to_auth_free = NULL;
@@ -145,9 +144,6 @@ main (int argc, char *argv[])
   if (argv[1] != NULL && strcmp (argv[1], "--socket-activated") == 0)
     {
       socklen_t socklen = sizeof(int);
-#ifdef SO_PEERCRED
-      struct ucred ucred;
-#endif
 
       user_to_auth_free = read_cookie (argc, argv);
       if (!user_to_auth_free)
@@ -171,22 +167,13 @@ main (int argc, char *argv[])
           goto error;
         }
 
-#ifdef SO_PEERCRED
-      socklen = sizeof(ucred);
-      rc = getsockopt(STDIN_FILENO, SOL_SOCKET, SO_PEERCRED, &ucred, &socklen);
-#else
-      rc = -1;
-#endif
-      if (rc < 0)
-        {
-          syslog (LOG_ERR, "Unable to get credentials from socket");
-          fprintf (stderr, "polkit-agent-helper-1: unable to get credentials from socket.\n");
-          goto error;
-        }
-
-#ifdef SO_PEERCRED
-      uid = ucred.uid;
-#endif
+      /* Deliberately do not take the uid from SO_PEERCRED: it reports the
+       * caller's *effective* uid, while polkitd identifies a process by its
+       * *real* uid (polkit_unix_process_get_racy_uid__()). The two differ for
+       * a setuid caller such as pkexec's built-in agent, and polkitd then
+       * fails to find the authentication session. Leave the uid unset so that
+       * PolkitUnixProcess derives it from the pidfd the same way polkitd does.
+       */
     }
   else
 #endif
@@ -288,7 +275,7 @@ main (int argc, char *argv[])
    * includes a) the cookie; b) the user we authenticated;
    * c) the pidfd and uid of the caller, if socket-activated
    */
-  if (!send_dbus_message (cookie, user_to_auth, pidfd, uid))
+  if (!send_dbus_message (cookie, user_to_auth, pidfd))
     {
 #ifdef PAH_DEBUG
       fprintf (stderr, "polkit-agent-helper-1: error sending D-Bus message to PolicyKit daemon\n");

--- a/src/polkitagent/polkitagenthelper-shadow.c
+++ b/src/polkitagent/polkitagenthelper-shadow.c
@@ -147,7 +147,7 @@ main (int argc, char *argv[])
   /* now send a D-Bus message to the PolicyKit daemon that
    * includes a) the cookie; and b) the user we authenticated
    */
-  if (!send_dbus_message (cookie, user_to_auth, -1, -1))
+  if (!send_dbus_message (cookie, user_to_auth, -1))
     {
 #ifdef PAH_DEBUG
       fprintf (stderr, "polkit-agent-helper-1: error sending D-Bus message to PolicyKit daemon\n");

--- a/src/polkitagent/polkitagenthelperprivate.c
+++ b/src/polkitagent/polkitagenthelperprivate.c
@@ -79,7 +79,7 @@ read_cookie (int argc, char **argv)
 }
 
 gboolean
-send_dbus_message (const char *cookie, const char *user, int pidfd, int uid)
+send_dbus_message (const char *cookie, const char *user, int pidfd)
 {
   PolkitAuthority *authority = NULL;
   PolkitIdentity *identity = NULL;
@@ -106,9 +106,10 @@ send_dbus_message (const char *cookie, const char *user, int pidfd, int uid)
       goto out;
     }
 
-  if (pidfd >= 0 && uid >= 0)
+  if (pidfd >= 0)
     {
-      subject = polkit_unix_process_new_pidfd (pidfd, uid, NULL);
+      /* uid -1 lets PolkitUnixProcess derive the process owner from the pidfd */
+      subject = polkit_unix_process_new_pidfd (pidfd, -1, NULL);
       ret = polkit_authority_authentication_agent_response_with_subject_sync (authority,
                                                                               cookie,
                                                                               identity,

--- a/src/polkitagent/polkitagenthelperprivate.h
+++ b/src/polkitagent/polkitagenthelperprivate.h
@@ -39,7 +39,7 @@ int _polkit_clearenv (void);
 
 char *read_cookie (int argc, char **argv);
 
-gboolean send_dbus_message (const char *cookie, const char *user, int pidfd, int uid);
+gboolean send_dbus_message (const char *cookie, const char *user, int pidfd);
 
 void flush_and_wait (void);
 


### PR DESCRIPTION
## Summary

The socket-activated `polkit-agent-helper-1` took the caller's uid from `SO_PEERCRED`, which reports the *effective* uid. polkitd identifies a process by its *real* uid. The two differ for a setuid caller such as `pkexec`'s built-in text agent, so the helper submitted uid 0 while the authentication session belonged to the invoking user, and `get_authentication_session_for_uid_and_cookie()` could not match it against `agent->creator_uid`.

The fix stops deriving the uid in the helper and leaves it unset, so `PolkitUnixProcess` derives it from the pidfd the same way polkitd does.

Closes #686

## Detailed description and/or reproducer

Two places already define a process owner as the real uid, and the helper was the only disagreement:

- `polkit_unix_process_get_owner()` reads `Uid:` from `/proc/PID/status` and takes the real field.
- `polkit_backend_session_monitor_get_user_for_subject()` cross-checks the subject uid against `polkit_unix_process_get_racy_uid__()`, so the old behaviour also made `matches` false.

Verified against current `main` (b3492d5) built and installed inside `ghcr.io/polkit-org/polkit-ai-reproducer-tools:fedora`, using the reproducer from the issue. `pkexec --version` reports 128 in both runs.

| case | before | after |
| --- | --- | --- |
| `pkexec id`, socket-activated helper (the bug) | exit 127, `Not authorized`, `No session for cookie`, helper unit `Failed with result 'exit-code'` | exit 0, `id` runs as root, helper unit `Finished` |
| non-setuid agent: `pkttyagent` plus `pkcheck --allow-user-interaction` | works | works, `pkcheck` exit 0 |
| legacy setuid helper, `polkit-agent-helper.socket` stopped | works | works, exit 0 |

The systemd unit name is a convenient probe here, since it records the uid the helper saw. Before the change every instance was `Agent Helper (PID N/UID 0)` even though the session belonged to uid 1000. After it, the `pkttyagent` run shows `Agent Helper (PID 495/UID 1000)`, confirming the non-setuid path still reports the same uid it always did.

Build is clean with no new warnings.

## AI assistance

Per the README policy: I used Claude (Opus) for the code reading, the reproduction and regression runs, and drafting this description. I have reviewed the change and the measurements and stand behind them.
