### PR TITLE
polkitagent: Fix use-after-free in io_watch_have_data()

### DIFF
--- a/src/polkitagent/polkitagentsession.c
+++ b/src/polkitagent/polkitagentsession.c
@@ -444,6 +444,13 @@ io_watch_have_data (GIOChannel    *channel,
       g_warning ("in io_watch_have_data() but helper is not supposed to be running");
 
       complete_session (session, FALSE);
+      /* complete_session() emits ::completed, and handlers of that signal
+       * are documented to be allowed to drop the last reference to
+       * @session (see e.g. PolkitAgentTextListener's handler). NULL out
+       * our local pointer so we can never call complete_session() again
+       * on a possibly-freed @session below.
+       */
+      session = NULL;
       goto out;
     }
 
@@ -461,6 +468,7 @@ io_watch_have_data (GIOChannel    *channel,
       g_clear_error (&error);
 
       complete_session (session, FALSE);
+      session = NULL;
       goto out;
     }
 
@@ -504,15 +512,18 @@ io_watch_have_data (GIOChannel    *channel,
   else if (g_str_has_prefix (unescaped, "SUCCESS"))
     {
       complete_session (session, TRUE);
+      session = NULL;
     }
   else if (g_str_has_prefix (unescaped, "FAILURE"))
     {
       complete_session (session, FALSE);
+      session = NULL;
     }
   else
     {
       g_warning ("Unknown line '%s' from helper", line);
       complete_session (session, FALSE);
+      session = NULL;
       goto out;
     }
 
@@ -520,7 +531,7 @@ io_watch_have_data (GIOChannel    *channel,
   g_free (line);
   g_free (unescaped);
 
-  if (condition & (G_IO_ERR | G_IO_HUP))
+  if (session != NULL && (condition & (G_IO_ERR | G_IO_HUP)))
     complete_session (session, FALSE);
 
   /* keep the IOChannel around */


### PR DESCRIPTION
complete_session() emits the "completed" signal, and handlers of that signal are explicitly documented (and, in the case of PolkitAgentTextListener, actually implemented) to be allowed to drop the last reference to the PolkitAgentSession.

io_watch_have_data() can call complete_session() once from one of its error/success branches and then unconditionally call it a second time from its epilogue whenever the dispatch also carries G_IO_ERR or G_IO_HUP. If the first call already caused the session to be freed via its "completed" handler, that second call operates on freed memory.

Fix this by NULLing out the local session pointer right after each complete_session() call, and skipping the epilogue's call when it is already NULL, so we never dereference a session that may have already been freed.

Comments and description co-authored-by @claude 
Reported by: aisle.com