### PR TITLE
pkexec: Only use realpath when given path has no action

### DIFF
--- a/src/programs/pkexec.c
+++ b/src/programs/pkexec.c
@@ -361,11 +361,6 @@ find_action_for_path (PolkitAuthority *authority,
   g_list_foreach (actions, (GFunc) g_object_unref, NULL);
   g_list_free (actions);
 
-  /* Fall back to org.freedesktop.policykit.exec */
-
-  if (action_id == NULL)
-    action_id = g_strdup ("org.freedesktop.policykit.exec");
-
   return action_id;
 }
 
@@ -705,16 +700,6 @@ main (int argc, char *argv[])
       }
     }
 
-  s = realpath(path, NULL);
-  if (s != NULL)
-    {
-      /* The called program resolved to the canonical location. We don't update
-       * argv[n] this time. The called program still sees the original
-       * called path. This is very important for multi-call binaries like
-       * busybox. */
-      g_free (path);
-      path = s;
-    }
   if (access (path, F_OK) != 0)
     {
       g_printerr ("Error accessing %s: %s\n", path, g_strerror (errno));
@@ -848,6 +833,32 @@ main (int argc, char *argv[])
                                     path,
                                     exec_argv[1],
                                     &allow_gui);
+
+  /* Also try the canonicalized path in case of merged-usr systems
+   * where PATH ordering might break finding the correct action.
+   */
+  if (action_id == NULL)
+    {
+      s = realpath(path, NULL);
+      if (s != NULL)
+        {
+          /* This intentionally doesn't change argv because
+           * multi-call binaries like busybox depend on it.
+           */
+          g_free (path);
+          path = s;
+
+          action_id = find_action_for_path (authority,
+                                            path,
+                                            exec_argv[1],
+                                            &allow_gui);
+        }
+    }
+
+  /* Fall back to org.freedesktop.policykit.exec */
+  if (action_id == NULL)
+    action_id = g_strdup ("org.freedesktop.policykit.exec");
+
   g_assert (action_id != NULL);
 
   details = polkit_details_new ();


### PR DESCRIPTION
## Summary
[short description of the problem and the change]: #

Like https://github.com/polkit-org/polkit/pull/509 already mentions always using `realpath` when comparing `org.freedesktop.policykit.exec.path` "might cause backwards incompatibility issues" which is why Gentoo currently can't/won't package polkit 127 (see https://bugs.gentoo.org/973130 https://bugs.gentoo.org/959152).

These changes restore the <127 behaviour by having a fallback chain like this: `User provided (potentially resolved from PATH) path -> Canonicalized (real-)path -> Fixed "org.freedesktop.policykit.exec"`

## Detailed description and/or reproducer
[Please be more descriptive yet concise here. This text will help us with testing, urgency and severity assessment.]: #

As seen in the linked [Gentoo bug](https://bugs.gentoo.org/959152) Gentoo supports both the `split-usr` and `merged-usr` configurations. On `merged-usr` systems e.g. `/usr/sbin` is a symlink to `/usr/bin` while on `split-usr` they're independent directories.
When you now tell a build system (for XFCE in this case) "hey `sbindir` is `/usr/sbin`" it'll install e.g. `/usr/sbin/xfpm-power-backlight-helper` there and write that same path in the relevant `.policy` file.
This works fine in the `split-usr` case (it is the `realpath`) but will result in not finding the matching action on `merged-usr` (`realpath` is `/usr/bin/xfpm-power-backlight-helper`).

I'd argue it makes sense to first always try to find whatever the user/caller provided and only fall back to looking at the `realpath` if there was no match.
Also while I haven't seen this being an issue I'd imagine always looking at `realpath` would break actions specifically targeting certain calls to multi-call binaries which this would allow as well.

Not sure if there are any security implications with this, but considering this basically just merged the <= v126 and v127 behaviour I'd say it's at least not worse than before.