### PR TITLE
CVE-2026-85498: Unsanitized underflow in cookie input

### DIFF
--- a/src/polkitagent/polkitagenthelperprivate.c
+++ b/src/polkitagent/polkitagenthelperprivate.c
@@ -68,6 +68,11 @@ read_cookie (int argc, char **argv)
             perror ("fgets");
           return NULL;
         }
+      if (buf[0] == '\0')
+        {
+          errno = EINVAL;
+          return NULL;
+        }
       if (buf[strlen (buf) - 1] != '\n')
         {
           errno = EOVERFLOW;


### PR DESCRIPTION
`strlen(buf)-1` can point before the actual buffer if `fgets` returns an empty, null-terminated string.

Credits for the report:
Sunwoo Lee, Korea Institute of Energy Technology (KENTECH)  
Daeyoung Kang, Korea Institute of Energy Technology (KENTECH)  
Haeryong Park, Korea Internet & Security Agency (KISA)  
Hyuk Lim, Korea Institute of Energy Technology (KENTECH)  
Seunghyun Yoon, Korea Institute of Energy Technology (KENTECH)  
Juthawong Naisanguansee (simultaneous discovery)
