### PR TITLE
ci: switch the Alpine job to the edge branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   alpine:
     runs-on: ubuntu-latest
     container:
-      image: alpine:latest
+      image: alpine:edge
       options: "--privileged"
     concurrency:
       group: alpine-${{ github.workflow }}-${{ github.ref }}-${{ matrix.phase }}


### PR DESCRIPTION
Apart from catching potential issues earlier, this should also finally fix the outstanding build fail in our Alpine CI job, as we need newer fortify-headers package with [0] that's currently only in the edge branch.

[0] https://github.com/jvoisin/fortify-headers/commit/b9121e4d679b5fccb69abcb58b05a6be5c7191dc